### PR TITLE
Improve nullable support for dto fields

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
@@ -1,10 +1,7 @@
 package io.github.kbuntrock;
 
 
-import io.github.kbuntrock.configuration.ApiConfiguration;
-import io.github.kbuntrock.configuration.CommonApiConfiguration;
-import io.github.kbuntrock.configuration.EnumConfigHolder;
-import io.github.kbuntrock.configuration.JavadocConfiguration;
+import io.github.kbuntrock.configuration.*;
 import io.github.kbuntrock.javadoc.JavadocMap;
 import io.github.kbuntrock.javadoc.JavadocParser;
 import io.github.kbuntrock.javadoc.JavadocWrapper;
@@ -119,6 +116,7 @@ public class DocumentationMojo extends AbstractMojo {
 		}
 		this.getApiConfiguration().initDefaultValues();
 		EnumConfigHolder.storeConfig(this.getApiConfiguration().getEnumConfigList());
+		NullableConfigurationHolder.storeConfig(this.getApiConfiguration());
 
 		for(final ApiConfiguration apiConfiguration : apis) {
 			if(apiConfiguration.getLocations() == null || apiConfiguration.getLocations().isEmpty()) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
@@ -61,6 +61,15 @@ public class CommonApiConfiguration {
 	protected Boolean loopbackOperationName;
 
 	@Parameter
+	protected Boolean defaultNonNullableFields;
+
+	@Parameter
+	protected String nonNullableAnnotation;
+
+	@Parameter
+	protected String nullableAnnotation;
+
+	@Parameter
 	protected String operationId;
 
 	@Parameter
@@ -107,6 +116,9 @@ public class CommonApiConfiguration {
 		this.library = commonApiConfiguration.library;
 		this.customResponseTypeAnnotation = commonApiConfiguration.customResponseTypeAnnotation;
 		this.defaultErrors = commonApiConfiguration.defaultErrors;
+		this.defaultNonNullableFields = commonApiConfiguration.defaultNonNullableFields;
+		this.nonNullableAnnotation = commonApiConfiguration.nonNullableAnnotation;
+		this.nullableAnnotation = commonApiConfiguration.nullableAnnotation;
 		for(final String tagAnnotation : commonApiConfiguration.tagAnnotations) {
 			this.tagAnnotations.add(tagAnnotation);
 		}
@@ -304,5 +316,29 @@ public class CommonApiConfiguration {
 
 	public void setDefaultErrors(final String defaultErrors) {
 		this.defaultErrors = defaultErrors;
+	}
+
+	public Boolean getDefaultNonNullableFields() {
+		return defaultNonNullableFields;
+	}
+
+	public void setDefaultNonNullableFields(Boolean defaultNonNullableFields) {
+		this.defaultNonNullableFields = defaultNonNullableFields;
+	}
+
+	public String getNonNullableAnnotation() {
+		return nonNullableAnnotation;
+	}
+
+	public void setNonNullableAnnotation(String nonNullableAnnotation) {
+		this.nonNullableAnnotation = nonNullableAnnotation;
+	}
+
+	public String getNullableAnnotation() {
+		return nullableAnnotation;
+	}
+
+	public void setNullableAnnotation(String nullableAnnotation) {
+		this.nullableAnnotation = nullableAnnotation;
 	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/NullableConfigurationHolder.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/NullableConfigurationHolder.java
@@ -1,0 +1,30 @@
+package io.github.kbuntrock.configuration;
+
+public class NullableConfigurationHolder {
+
+    private static String nullableAnnotation;
+
+    private static String nonNullAnnotation;
+
+    private static boolean defaultNonNullableFields;
+
+    public static void storeConfig(final CommonApiConfiguration commonApiConfiguration) {
+        nullableAnnotation = commonApiConfiguration.nullableAnnotation;
+        nonNullAnnotation = commonApiConfiguration.nonNullableAnnotation;
+        defaultNonNullableFields = commonApiConfiguration.defaultNonNullableFields != null
+                && commonApiConfiguration.defaultNonNullableFields;
+
+    }
+
+    public static String getNullableAnnotation() {
+        return nullableAnnotation;
+    }
+
+    public static String getNonNullAnnotation() {
+        return nonNullAnnotation;
+    }
+
+    public static boolean isDefaultNonNullableFields() {
+        return defaultNonNullableFields;
+    }
+}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
@@ -1,15 +1,11 @@
 package io.github.kbuntrock.yaml.model;
 
-import static io.github.kbuntrock.TagLibrary.METHOD_GET_PREFIX;
-import static io.github.kbuntrock.TagLibrary.METHOD_GET_PREFIX_SIZE;
-import static io.github.kbuntrock.TagLibrary.METHOD_IS_PREFIX;
-import static io.github.kbuntrock.TagLibrary.METHOD_IS_PREFIX_SIZE;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.kbuntrock.JavaClassAnalyser;
 import io.github.kbuntrock.TagLibraryHolder;
+import io.github.kbuntrock.configuration.NullableConfigurationHolder;
 import io.github.kbuntrock.javadoc.ClassDocumentation;
 import io.github.kbuntrock.javadoc.ClassDocumentation.EnhancementType;
 import io.github.kbuntrock.javadoc.JavadocMap;
@@ -20,323 +16,347 @@ import io.github.kbuntrock.reflection.ReflectionsUtils;
 import io.github.kbuntrock.utils.Logger;
 import io.github.kbuntrock.utils.OpenApiConstants;
 import io.github.kbuntrock.utils.OpenApiDataFormat;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static io.github.kbuntrock.TagLibrary.*;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Schema {
 
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	protected String description;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	protected List<String> required;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	protected String type;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	protected String format;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	protected Map<String, Property> properties;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	@JsonProperty("enum")
-	protected List<String> enumValues;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	@JsonProperty("x-enumNames")
-	protected List<String> enumNames;
-	// Used in case of a Map object
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	protected Schema additionalProperties;
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	@JsonProperty(OpenApiConstants.OBJECT_REFERENCE_DECLARATION)
-	protected String reference;
-	// Used in case of an array object
-	@JsonInclude(JsonInclude.Include.NON_NULL)
-	protected Schema items;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected String description;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected List<String> required;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected String type;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected String format;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected Map<String, Property> properties;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("enum")
+    protected List<String> enumValues;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("x-enumNames")
+    protected List<String> enumNames;
+    // Used in case of a Map object
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected Schema additionalProperties;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(OpenApiConstants.OBJECT_REFERENCE_DECLARATION)
+    protected String reference;
+    // Used in case of an array object
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    protected Schema items;
 
-	/**
-	 * If true, we cannot reference the main object (we are using this object is the "schemas" section).
-	 */
-	@JsonIgnore
-	private boolean mainReference = false;
-	@JsonIgnore
-	private DataObject parentDataObject;
-	@JsonIgnore
-	private String parentFieldName;
+    /**
+     * If true, we cannot reference the main object (we are using this object is the "schemas" section).
+     */
+    @JsonIgnore
+    private boolean mainReference = false;
+    @JsonIgnore
+    private DataObject parentDataObject;
+    @JsonIgnore
+    private String parentFieldName;
 
 
-	public Schema() {
-	}
+    public Schema() {
+    }
 
-	public Schema(final DataObject dataObject, final Set<String> exploredSignatures) {
-		this(dataObject, false, exploredSignatures, null, null);
-	}
+    public Schema(final DataObject dataObject, final Set<String> exploredSignatures) {
+        this(dataObject, false, exploredSignatures, null, null);
+    }
 
-	public Schema(final DataObject dataObject, final boolean mainReference, final Set<String> exploredSignatures,
-		final DataObject parentDataObject,
-		final String parentFieldName) {
+    public Schema(final DataObject dataObject, final boolean mainReference, final Set<String> exploredSignatures,
+                  final DataObject parentDataObject,
+                  final String parentFieldName) {
 
-		this.mainReference = mainReference;
+        this.mainReference = mainReference;
 
-		// Javadoc handling
-		ClassDocumentation classDocumentation = null;
-		if(JavadocMap.INSTANCE.isPresent()) {
-			classDocumentation = JavadocMap.INSTANCE.getJavadocMap().get(dataObject.getJavaClass().getCanonicalName());
-			if(classDocumentation != null) {
-				classDocumentation.inheritanceEnhancement(dataObject.getJavaClass(), EnhancementType.BOTH);
-			}
-			if(classDocumentation != null && mainReference) {
-				final Optional<String> optionalDescription = classDocumentation.getDescription();
-				if(optionalDescription.isPresent()) {
-					description = optionalDescription.get();
-				}
-			}
-		}
+        // Javadoc handling
+        ClassDocumentation classDocumentation = null;
+        if (JavadocMap.INSTANCE.isPresent()) {
+            classDocumentation = JavadocMap.INSTANCE.getJavadocMap().get(dataObject.getJavaClass().getCanonicalName());
+            if (classDocumentation != null) {
+                classDocumentation.inheritanceEnhancement(dataObject.getJavaClass(), EnhancementType.BOTH);
+            }
+            if (classDocumentation != null && mainReference) {
+                final Optional<String> optionalDescription = classDocumentation.getDescription();
+                if (optionalDescription.isPresent()) {
+                    description = optionalDescription.get();
+                }
+            }
+        }
 
-		if(dataObject.isMap()) {
-			type = dataObject.getOpenApiType().getValue();
-			additionalProperties = new Schema(dataObject.getMapValueType(), false, exploredSignatures, parentDataObject, parentFieldName);
+        if (dataObject.isMap()) {
+            type = dataObject.getOpenApiType().getValue();
+            additionalProperties = new Schema(dataObject.getMapValueType(), false, exploredSignatures, parentDataObject, parentFieldName);
 
-		} else if(dataObject.isOpenApiArray()) {
-			type = dataObject.getOpenApiType().getValue();
-			items = new Schema(dataObject.getArrayItemDataObject(), false, exploredSignatures, parentDataObject, parentFieldName);
+        } else if (dataObject.isOpenApiArray()) {
+            type = dataObject.getOpenApiType().getValue();
+            items = new Schema(dataObject.getArrayItemDataObject(), false, exploredSignatures, parentDataObject, parentFieldName);
 
-		} else if(!mainReference && dataObject.isReferenceObject()) {
-			final DataObject referenceDataObject = TagLibraryHolder.INSTANCE.getTagLibrary().getClassToSchemaObject()
-				.get(dataObject.getJavaClass());
-			if(referenceDataObject == null) {
-				// Investigation on a rare bug where the reference is not found.
-				throw new RuntimeException(
-					"Writing schema but could not find a reference for class " + dataObject.getJavaClass().getSimpleName());
-			}
-			reference = OpenApiConstants.OBJECT_REFERENCE_PREFIX + referenceDataObject.getSchemaReferenceName();
+        } else if (!mainReference && dataObject.isReferenceObject()) {
+            final DataObject referenceDataObject = TagLibraryHolder.INSTANCE.getTagLibrary().getClassToSchemaObject()
+                    .get(dataObject.getJavaClass());
+            if (referenceDataObject == null) {
+                // Investigation on a rare bug where the reference is not found.
+                throw new RuntimeException(
+                        "Writing schema but could not find a reference for class " + dataObject.getJavaClass().getSimpleName());
+            }
+            reference = OpenApiConstants.OBJECT_REFERENCE_PREFIX + referenceDataObject.getSchemaReferenceName();
 
-		} else if((mainReference && dataObject.isReferenceObject() || dataObject.isGenericallyTypedObject())) {
+        } else if ((mainReference && dataObject.isReferenceObject() || dataObject.isGenericallyTypedObject())) {
 
-			boolean forcedReference = false;
-			String referenceSignature = null;
-			if(parentDataObject != null && parentFieldName != null) {
-				final String objectSignature =
-					parentDataObject.getJavaClass().getSimpleName() + "_" + parentFieldName + "_" + dataObject.getSignature();
-				if(!exploredSignatures.add(objectSignature)) {
-					// The fieldname + signature has already be seen. We are in a recursive loop
-					// We will have to write this field in the schema section.
-					referenceSignature = parentDataObject.getJavaClass().getSimpleName() + "_" + dataObject.getSchemaRecursiveSuffix();
-					AdditionnalSchemaLibrary.addDataObject(referenceSignature, dataObject);
-					forcedReference = true;
-				}
-			}
+            boolean forcedReference = false;
+            String referenceSignature = null;
+            if (parentDataObject != null && parentFieldName != null) {
+                final String objectSignature =
+                        parentDataObject.getJavaClass().getSimpleName() + "_" + parentFieldName + "_" + dataObject.getSignature();
+                if (!exploredSignatures.add(objectSignature)) {
+                    // The fieldname + signature has already be seen. We are in a recursive loop
+                    // We will have to write this field in the schema section.
+                    referenceSignature = parentDataObject.getJavaClass().getSimpleName() + "_" + dataObject.getSchemaRecursiveSuffix();
+                    AdditionnalSchemaLibrary.addDataObject(referenceSignature, dataObject);
+                    forcedReference = true;
+                }
+            }
 
-			if(!forcedReference) {
-				type = dataObject.getOpenApiType().getValue();
+            if (!forcedReference) {
+                type = dataObject.getOpenApiType().getValue();
 
-				// LinkedHashMap to keep the order of the class
-				properties = new LinkedHashMap<>();
+                // LinkedHashMap to keep the order of the class
+                properties = new LinkedHashMap<>();
 
-				final List<Field> fields = ReflectionsUtils.getAllNonStaticFields(new ArrayList<>(), dataObject.getJavaClass());
-				if(!fields.isEmpty() && !dataObject.isEnum()) {
+                final List<Field> fields = ReflectionsUtils.getAllNonStaticFields(new ArrayList<>(), dataObject.getJavaClass());
+                if (!fields.isEmpty() && !dataObject.isEnum()) {
 
-					for(final Field field : fields) {
-						if(field.isAnnotationPresent(JsonIgnore.class)) {
-							// Field is tagged ignore. No need to document it.
-							continue;
-						}
+                    for (final Field field : fields) {
+                        if (field.isAnnotationPresent(JsonIgnore.class)) {
+                            // Field is tagged ignore. No need to document it.
+                            continue;
+                        }
 
-						final DataObject propertyObject = new DataObject(dataObject.getContextualType(field.getGenericType()));
-						final Property property = new Property(propertyObject, false, field.getName(), exploredSignatures, dataObject);
-						extractConstraints(field, property);
-						properties.put(property.getName(), property);
+                        final DataObject propertyObject = new DataObject(dataObject.getContextualType(field.getGenericType()));
+                        final Property property = new Property(propertyObject, false, field.getName(), exploredSignatures, dataObject);
+                        extractConstraints(field, property);
+                        properties.put(property.getName(), property);
 
-						// Javadoc handling
-						if(classDocumentation != null) {
-							final JavadocWrapper javadocWrapper = classDocumentation.getFieldsJavadoc().get(field.getName());
-							if(javadocWrapper != null) {
-								final Optional<String> desc = javadocWrapper.getDescription();
-								property.setDescription(desc.get());
-							}
-						}
-					}
-				}
-				if(dataObject.getJavaClass().isInterface()) {
-					final List<Method> methods = Arrays.stream(dataObject.getJavaClass().getMethods()).collect(Collectors.toList());
-					methods.sort(Comparator.comparing(a -> a.getName()));
-					for(final Method method : methods) {
-						final boolean methodStartWithGet =
-							method.getName().startsWith(METHOD_GET_PREFIX) && method.getName().length() != METHOD_GET_PREFIX_SIZE;
-						if(method.getParameters().length == 0 && method.getGenericReturnType() != null
-							&& (methodStartWithGet || (method.getName().startsWith(METHOD_IS_PREFIX)
-							&& method.getName().length() != METHOD_IS_PREFIX_SIZE))) {
+                        // Javadoc handling
+                        if (classDocumentation != null) {
+                            final JavadocWrapper javadocWrapper = classDocumentation.getFieldsJavadoc().get(field.getName());
+                            if (javadocWrapper != null) {
+                                final Optional<String> desc = javadocWrapper.getDescription();
+                                property.setDescription(desc.get());
+                            }
+                        }
+                    }
+                }
+                if (dataObject.getJavaClass().isInterface()) {
+                    final List<Method> methods = Arrays.stream(dataObject.getJavaClass().getMethods()).collect(Collectors.toList());
+                    methods.sort(Comparator.comparing(a -> a.getName()));
+                    for (final Method method : methods) {
+                        final boolean methodStartWithGet =
+                                method.getName().startsWith(METHOD_GET_PREFIX) && method.getName().length() != METHOD_GET_PREFIX_SIZE;
+                        if (method.getParameters().length == 0 && method.getGenericReturnType() != null
+                                && (methodStartWithGet || (method.getName().startsWith(METHOD_IS_PREFIX)
+                                && method.getName().length() != METHOD_IS_PREFIX_SIZE))) {
 
-							String name;
-							if(methodStartWithGet) {
-								name = method.getName().replaceFirst("get", "");
-							} else {
-								name = method.getName().replaceFirst("is", "");
-							}
-							Logger.INSTANCE.getLogger()
-								.debug(dataObject.getJavaClass().getSimpleName() + " method name : " + method.getName() + " - " + name);
-							name = name.substring(0, 1).toLowerCase() + name.substring(1);
+                            String name;
+                            if (methodStartWithGet) {
+                                name = method.getName().replaceFirst("get", "");
+                            } else {
+                                name = method.getName().replaceFirst("is", "");
+                            }
+                            Logger.INSTANCE.getLogger()
+                                    .debug(dataObject.getJavaClass().getSimpleName() + " method name : " + method.getName() + " - " + name);
+                            name = name.substring(0, 1).toLowerCase() + name.substring(1);
 
-							final DataObject propertyObject = new DataObject(dataObject.getContextualType(method.getGenericReturnType()));
-							final Property property = new Property(propertyObject, false, name, exploredSignatures, dataObject);
-							properties.put(property.getName(), property);
+                            final DataObject propertyObject = new DataObject(dataObject.getContextualType(method.getGenericReturnType()));
+                            final Property property = new Property(propertyObject, false, name, exploredSignatures, dataObject);
+                            properties.put(property.getName(), property);
 
-							// Javadoc handling
-							if(classDocumentation != null) {
-								final JavadocWrapper javadocWrapper = classDocumentation.getMethodsJavadoc()
-									.get(JavaClassAnalyser.createIdentifier(method));
-								if(javadocWrapper != null) {
-									final Optional<String> desc = javadocWrapper.getDescription();
-									property.setDescription(desc.get());
-								}
-							}
-						}
-					}
+                            // Javadoc handling
+                            if (classDocumentation != null) {
+                                final JavadocWrapper javadocWrapper = classDocumentation.getMethodsJavadoc()
+                                        .get(JavaClassAnalyser.createIdentifier(method));
+                                if (javadocWrapper != null) {
+                                    final Optional<String> desc = javadocWrapper.getDescription();
+                                    property.setDescription(desc.get());
+                                }
+                            }
+                        }
+                    }
 
-				}
+                }
 
-				final List<String> enumItemValues = dataObject.getEnumItemValues();
-				if(enumItemValues != null && !enumItemValues.isEmpty()) {
-					enumValues = enumItemValues;
-					enumNames = dataObject.getEnumItemNames();
-					if(classDocumentation != null) {
-						final StringBuilder sb = new StringBuilder();
-						if(description != null) {
-							sb.append(description);
-							sb.append("\n");
-						} else {
-							sb.append(dataObject.getJavaClass().getSimpleName());
-							sb.append("\n");
-						}
-						for(int i = 0; i < enumItemValues.size(); i++) {
-							final String value = enumNames == null ? enumItemValues.get(i) : enumNames.get(i);
-							final JavadocWrapper javadocWrapper = classDocumentation.getFieldsJavadoc().get(value);
-							if(javadocWrapper != null) {
-								final Optional<String> desc = javadocWrapper.getDescription();
-								if(desc.isPresent()) {
-									sb.append("  * ");
-									sb.append("`");
-									sb.append(value);
-									sb.append("` - ");
-									sb.append(desc.get());
-									sb.append("\n");
-								}
-							}
-						}
-						description = sb.toString();
-					}
-				}
+                final List<String> enumItemValues = dataObject.getEnumItemValues();
+                if (enumItemValues != null && !enumItemValues.isEmpty()) {
+                    enumValues = enumItemValues;
+                    enumNames = dataObject.getEnumItemNames();
+                    if (classDocumentation != null) {
+                        final StringBuilder sb = new StringBuilder();
+                        if (description != null) {
+                            sb.append(description);
+                            sb.append("\n");
+                        } else {
+                            sb.append(dataObject.getJavaClass().getSimpleName());
+                            sb.append("\n");
+                        }
+                        for (int i = 0; i < enumItemValues.size(); i++) {
+                            final String value = enumNames == null ? enumItemValues.get(i) : enumNames.get(i);
+                            final JavadocWrapper javadocWrapper = classDocumentation.getFieldsJavadoc().get(value);
+                            if (javadocWrapper != null) {
+                                final Optional<String> desc = javadocWrapper.getDescription();
+                                if (desc.isPresent()) {
+                                    sb.append("  * ");
+                                    sb.append("`");
+                                    sb.append(value);
+                                    sb.append("` - ");
+                                    sb.append(desc.get());
+                                    sb.append("\n");
+                                }
+                            }
+                        }
+                        description = sb.toString();
+                    }
+                }
 
-				required = properties.values().stream()
-					.filter(Property::isRequired).map(Property::getName).collect(Collectors.toList());
-			} else {
-				// We are in a recursive loop case. We write the object as reference and we will have to add it to the schema section
-				reference = OpenApiConstants.OBJECT_REFERENCE_PREFIX + referenceSignature;
-			}
+                required = properties.values().stream()
+                        .filter(Property::isRequired).map(Property::getName).collect(Collectors.toList());
+            } else {
+                // We are in a recursive loop case. We write the object as reference and we will have to add it to the schema section
+                reference = OpenApiConstants.OBJECT_REFERENCE_PREFIX + referenceSignature;
+            }
 
-		} else {
-			type = dataObject.getOpenApiType().getValue();
-			final OpenApiDataFormat openApiDataFormat = dataObject.getOpenApiType().getFormat();
-			if(OpenApiDataFormat.NONE != openApiDataFormat && OpenApiDataFormat.UNKNOWN != openApiDataFormat) {
-				this.format = openApiDataFormat.getValue();
-			}
-		}
-	}
+        } else {
+            type = dataObject.getOpenApiType().getValue();
+            final OpenApiDataFormat openApiDataFormat = dataObject.getOpenApiType().getFormat();
+            if (OpenApiDataFormat.NONE != openApiDataFormat && OpenApiDataFormat.UNKNOWN != openApiDataFormat) {
+                this.format = openApiDataFormat.getValue();
+            }
+        }
+    }
 
-	private void extractConstraints(final Field field, final Property property) {
-		final Size size = field.getAnnotation(Size.class);
-		if(size != null) {
-			property.setMinLength(size.min());
-			if(size.max() != Integer.MAX_VALUE) {
-				property.setMaxLength(size.max());
-			}
-		}
+    private void extractConstraints(final Field field, final Property property) {
+        final Size size = field.getAnnotation(Size.class);
+        if (size != null) {
+            property.setMinLength(size.min());
+            if (size.max() != Integer.MAX_VALUE) {
+                property.setMaxLength(size.max());
+            }
+        }
 
-		final NotNull notNull = field.getAnnotation(NotNull.class);
-		if(notNull != null) {
-			property.setRequired(true);
-		}
-	}
+        if (hasNonNullAnnotation(field)) {
+            property.setRequired(true);
+        } else if (hasNullableAnnotation(field)) {
+            property.setRequired(false);
+        } else {
+            property.setRequired(NullableConfigurationHolder.isDefaultNonNullableFields());
+        }
+    }
 
-	public List<String> getRequired() {
-		return required;
-	}
+    private boolean hasNullableAnnotation(final Field field) {
+        final String nullableAnnotation = NullableConfigurationHolder.getNullableAnnotation();
+        if (nullableAnnotation != null) {
+            return Arrays.stream(field.getAnnotations())
+                    .map(annotation -> annotation.annotationType().getName())
+                    .anyMatch(name -> name.equals(nullableAnnotation));
+        }
 
-	public void setRequired(final List<String> required) {
-		this.required = required;
-	}
+        final Nullable nullable = field.getAnnotation(Nullable.class);
+        return nullable != null;
+    }
 
-	public String getType() {
-		return type;
-	}
+    private boolean hasNonNullAnnotation(final Field field) {
+        final String nonNullAnnotation = NullableConfigurationHolder.getNonNullAnnotation();
+        if (nonNullAnnotation != null) {
+            return Arrays.stream(field.getAnnotations())
+                    .map(annotation -> annotation.annotationType().getName())
+                    .anyMatch(name -> name.equals(nonNullAnnotation));
+        }
 
-	public void setType(final String type) {
-		this.type = type;
-	}
+        final NotNull notNull = field.getAnnotation(NotNull.class);
+        return notNull != null;
+    }
 
-	public Map<String, Property> getProperties() {
-		return properties;
-	}
+    public List<String> getRequired() {
+        return required;
+    }
 
-	public void setProperties(final Map<String, Property> properties) {
-		this.properties = properties;
-	}
+    public void setRequired(final List<String> required) {
+        this.required = required;
+    }
 
-	public List<String> getEnumValues() {
-		return enumValues;
-	}
+    public String getType() {
+        return type;
+    }
 
-	public void setEnumValues(final List<String> enumValues) {
-		this.enumValues = enumValues;
-	}
+    public void setType(final String type) {
+        this.type = type;
+    }
 
-	public String getFormat() {
-		return format;
-	}
+    public Map<String, Property> getProperties() {
+        return properties;
+    }
 
-	public void setFormat(final String format) {
-		this.format = format;
-	}
+    public void setProperties(final Map<String, Property> properties) {
+        this.properties = properties;
+    }
 
-	public Schema getAdditionalProperties() {
-		return additionalProperties;
-	}
+    public List<String> getEnumValues() {
+        return enumValues;
+    }
 
-	public void setAdditionalProperties(final Schema additionalProperties) {
-		this.additionalProperties = additionalProperties;
-	}
+    public void setEnumValues(final List<String> enumValues) {
+        this.enumValues = enumValues;
+    }
 
-	public String getReference() {
-		return reference;
-	}
+    public String getFormat() {
+        return format;
+    }
 
-	public void setReference(final String reference) {
-		this.reference = reference;
-	}
+    public void setFormat(final String format) {
+        this.format = format;
+    }
 
-	public Schema getItems() {
-		return items;
-	}
+    public Schema getAdditionalProperties() {
+        return additionalProperties;
+    }
 
-	public void setItems(final Schema items) {
-		this.items = items;
-	}
+    public void setAdditionalProperties(final Schema additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getReference() {
+        return reference;
+    }
 
-	public void setDescription(final String description) {
-		this.description = description;
-	}
+    public void setReference(final String reference) {
+        this.reference = reference;
+    }
+
+    public Schema getItems() {
+        return items;
+    }
+
+    public void setItems(final Schema items) {
+        this.items = items;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
 
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
@@ -2,11 +2,7 @@ package io.github.kbuntrock;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import io.github.kbuntrock.configuration.ApiConfiguration;
-import io.github.kbuntrock.configuration.EnumConfig;
-import io.github.kbuntrock.configuration.JavadocConfiguration;
-import io.github.kbuntrock.configuration.OperationIdHelper;
-import io.github.kbuntrock.configuration.Substitution;
+import io.github.kbuntrock.configuration.*;
 import io.github.kbuntrock.configuration.library.TagAnnotation;
 import io.github.kbuntrock.model.Tag;
 import io.github.kbuntrock.resources.dto.TerritoryEnum;
@@ -43,6 +39,7 @@ import io.github.kbuntrock.resources.endpoint.generic.Issue95;
 import io.github.kbuntrock.resources.endpoint.ignore.JsonIgnoreController;
 import io.github.kbuntrock.resources.endpoint.interfacedto.InterfaceController;
 import io.github.kbuntrock.resources.endpoint.map.MapController;
+import io.github.kbuntrock.resources.endpoint.nullable.NullableController;
 import io.github.kbuntrock.resources.endpoint.number.NumberController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementOneController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementTwoController;
@@ -732,6 +729,53 @@ public class SpringClassAnalyserTest extends AbstractTest {
 		}).isInstanceOf(MojoRuntimeException.class)
 			.hasMessageContaining("More than one operation mapped on GET : /api/controller-3/info in tag MyController");
 	}
+
+	@Test
+	public void nullable_default() throws MojoExecutionException, MojoFailureException, IOException {
+		final DocumentationMojo mojo = createBasicMojo(NullableController.class.getCanonicalName());
+		final CommonApiConfiguration commonApiConfiguration = new CommonApiConfiguration();
+		mojo.setApiConfiguration(commonApiConfiguration);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/nullable_default.yml", generated.get(0));
+	}
+
+	@Test
+	public void nullable_default_custom_annotation() throws MojoExecutionException, MojoFailureException, IOException {
+		final DocumentationMojo mojo = createBasicMojo(NullableController.class.getCanonicalName());
+		final CommonApiConfiguration commonApiConfiguration = new CommonApiConfiguration();
+		commonApiConfiguration.setNonNullableAnnotation("io.github.kbuntrock.resources.dto.nullable.MyNotNull");
+		commonApiConfiguration.setNullableAnnotation("io.github.kbuntrock.resources.dto.nullable.MyNullable");
+		mojo.setApiConfiguration(commonApiConfiguration);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/nullable_default_custom_annotation.yml", generated.get(0));
+	}
+
+	@Test
+	public void nullable_default_non_nullable() throws MojoExecutionException, MojoFailureException, IOException {
+		final DocumentationMojo mojo = createBasicMojo(NullableController.class.getCanonicalName());
+		final CommonApiConfiguration commonApiConfiguration = new CommonApiConfiguration();
+		commonApiConfiguration.setDefaultNonNullableFields(true);
+		mojo.setApiConfiguration(commonApiConfiguration);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/nullable_default_non_nullable.yml", generated.get(0));
+	}
+
+	@Test
+	public void nullable_default_non_nullable_custom_annotation() throws MojoExecutionException, MojoFailureException, IOException {
+		final DocumentationMojo mojo = createBasicMojo(NullableController.class.getCanonicalName());
+		final CommonApiConfiguration commonApiConfiguration = new CommonApiConfiguration();
+		commonApiConfiguration.setDefaultNonNullableFields(true);
+		commonApiConfiguration.setNonNullableAnnotation("io.github.kbuntrock.resources.dto.nullable.MyNotNull");
+		commonApiConfiguration.setNullableAnnotation("io.github.kbuntrock.resources.dto.nullable.MyNullable");
+		mojo.setApiConfiguration(commonApiConfiguration);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/nullable_default_non_nullable_custom_annotation.yml", generated.get(0));
+	}
+
 
 
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/MyNotNull.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/MyNotNull.java
@@ -1,0 +1,11 @@
+package io.github.kbuntrock.resources.dto.nullable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.When;
+import java.lang.annotation.*;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyNotNull {
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/MyNullable.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/MyNullable.java
@@ -1,0 +1,9 @@
+package io.github.kbuntrock.resources.dto.nullable;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyNullable {
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/NullableDto.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/nullable/NullableDto.java
@@ -1,0 +1,22 @@
+package io.github.kbuntrock.resources.dto.nullable;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+public class NullableDto {
+
+    private String defaultValue;
+
+    @NotNull
+    private String notNullableValue;
+
+    @Nullable
+    private String nullableValue;
+
+    @MyNotNull
+    private String myNotNull;
+
+    @MyNullable
+    private String myNullable;
+
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/nullable/NullableController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/nullable/NullableController.java
@@ -1,0 +1,14 @@
+package io.github.kbuntrock.resources.endpoint.nullable;
+
+import io.github.kbuntrock.resources.Constants;
+import io.github.kbuntrock.resources.dto.AccountDto;
+import io.github.kbuntrock.resources.dto.UserGroupDto;
+import io.github.kbuntrock.resources.dto.nullable.NullableDto;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/nullable")
+public interface NullableController {
+
+    @GetMapping("/{id}")
+    NullableDto getById(@PathVariable(value = "id") Long id);
+}

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default.yml
@@ -1,0 +1,46 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: NullableController
+paths:
+  /nullable/{id}:
+    get:
+      tags:
+        - NullableController
+      operationId: getById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NullableDto'
+components:
+  schemas:
+    NullableDto:
+      required:
+        - notNullableValue
+      type: object
+      properties:
+        defaultValue:
+          type: string
+        notNullableValue:
+          type: string
+        nullableValue:
+          type: string
+        myNotNull:
+          type: string
+        myNullable:
+          type: string

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_custom_annotation.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_custom_annotation.yml
@@ -1,0 +1,46 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: NullableController
+paths:
+  /nullable/{id}:
+    get:
+      tags:
+        - NullableController
+      operationId: getById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NullableDto'
+components:
+  schemas:
+    NullableDto:
+      required:
+        - myNotNull
+      type: object
+      properties:
+        defaultValue:
+          type: string
+        notNullableValue:
+          type: string
+        nullableValue:
+          type: string
+        myNotNull:
+          type: string
+        myNullable:
+          type: string

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_non_nullable.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_non_nullable.yml
@@ -1,0 +1,49 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: NullableController
+paths:
+  /nullable/{id}:
+    get:
+      tags:
+        - NullableController
+      operationId: getById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NullableDto'
+components:
+  schemas:
+    NullableDto:
+      required:
+        - defaultValue
+        - notNullableValue
+        - myNotNull
+        - myNullable
+      type: object
+      properties:
+        defaultValue:
+          type: string
+        notNullableValue:
+          type: string
+        nullableValue:
+          type: string
+        myNotNull:
+          type: string
+        myNullable:
+          type: string

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_non_nullable_custom_annotation.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/nullable_default_non_nullable_custom_annotation.yml
@@ -1,0 +1,49 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: NullableController
+paths:
+  /nullable/{id}:
+    get:
+      tags:
+        - NullableController
+      operationId: getById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/NullableDto'
+components:
+  schemas:
+    NullableDto:
+      required:
+        - defaultValue
+        - notNullableValue
+        - nullableValue
+        - myNotNull
+      type: object
+      properties:
+        defaultValue:
+          type: string
+        notNullableValue:
+          type: string
+        nullableValue:
+          type: string
+        myNotNull:
+          type: string
+        myNullable:
+          type: string


### PR DESCRIPTION
The purpose of this change is to allow better control over nullable settings when generating the dto generation. 

Basically it add support for configuring if fields should be considered non-nullable by default "defaultNonNullableFields", this is really the most important part of the change as I'm migrating from another tool which had that behavior so having this as a configuration option would really help with migrating. 

Then the nullable/nonnull annotations (both will be needed with this new option) currently use the javax version as default which will not work if you have a project migrate to jakarta (or you want to use jetbeans or similar). Therefore I added support for setting custom annotations to indicate what you want to use.