### PR TITLE
Adds Jackson's @JsonProperty handling on class attributes and a simple unit test

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
@@ -8,6 +8,7 @@ import static io.github.kbuntrock.TagLibrary.METHOD_IS_PREFIX_SIZE;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.kbuntrock.JavaClassAnalyser;
 import io.github.kbuntrock.TagLibraryHolder;
@@ -155,9 +156,16 @@ public class Schema {
 								// Field is tagged ignore. No need to document it.
 								continue;
 							}
-
+							// Jackson @JsonProperty annotation handling
+							String propertyFieldName = field.getName();
+							if (field.isAnnotationPresent(JsonProperty.class)) {
+								final JsonProperty jsonPropertyField = field.getAnnotation(JsonProperty.class);
+								if (!jsonPropertyField.value().isEmpty()) {
+									propertyFieldName = jsonPropertyField.value();
+								}
+							}
 							final DataObject propertyObject = new DataObject(dataObject.getContextualType(field.getGenericType()));
-							final Property property = new Property(propertyObject, false, field.getName(), exploredSignatures, dataObject);
+							final Property property = new Property(propertyObject, false, propertyFieldName, exploredSignatures, dataObject);
 							extractConstraints(field, property);
 							properties.put(property.getName(), property);
 

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
@@ -42,6 +42,7 @@ import io.github.kbuntrock.resources.endpoint.generic.Issue89;
 import io.github.kbuntrock.resources.endpoint.generic.Issue95;
 import io.github.kbuntrock.resources.endpoint.ignore.JsonIgnoreController;
 import io.github.kbuntrock.resources.endpoint.interfacedto.InterfaceController;
+import io.github.kbuntrock.resources.endpoint.jackson.JacksonJsonPropertyController;
 import io.github.kbuntrock.resources.endpoint.map.MapController;
 import io.github.kbuntrock.resources.endpoint.number.NumberController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementOneController;
@@ -731,6 +732,19 @@ public class SpringClassAnalyserTest extends AbstractTest {
 			mojo.documentProject();
 		}).isInstanceOf(MojoRuntimeException.class)
 			.hasMessageContaining("More than one operation mapped on GET : /api/controller-3/info in tag MyController");
+	}
+
+	@Test
+	public void jacksonJsonProperty() throws MojoFailureException, IOException, MojoExecutionException {
+
+		final DocumentationMojo mojo = createBasicMojo(JacksonJsonPropertyController.class.getCanonicalName());
+		final JavadocConfiguration javadocConfig = new JavadocConfiguration();
+		javadocConfig.setScanLocations(Arrays.asList("src/test/java/io/github/kbuntrock/resources/endpoint/jackson",
+				"src/test/java/io/github/kbuntrock/resources/dto/jackson"));
+		mojo.setJavadocConfiguration(javadocConfig);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/jackson_json_property.yml", generated.get(0));
 	}
 
 

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/jackson/SimpleUserDto.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/jackson/SimpleUserDto.java
@@ -1,0 +1,25 @@
+package io.github.kbuntrock.resources.dto.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A simple user
+ */
+public class SimpleUserDto {
+
+    /**
+     * User firstname
+     */
+    private String username;
+
+    /**
+     * Whether the user is active or not
+     */
+    @JsonProperty("isActive")
+    private boolean active;
+
+    /**
+     * Whether the user is an admin or not
+     */
+    private boolean admin;
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/jackson/SimpleUserDto.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/jackson/SimpleUserDto.java
@@ -21,5 +21,6 @@ public class SimpleUserDto {
     /**
      * Whether the user is an admin or not
      */
+    @JsonProperty
     private boolean admin;
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/jackson/JacksonJsonPropertyController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/jackson/JacksonJsonPropertyController.java
@@ -1,0 +1,25 @@
+package io.github.kbuntrock.resources.endpoint.jackson;
+
+import io.github.kbuntrock.resources.Constants;
+import io.github.kbuntrock.resources.dto.jackson.SimpleUserDto;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Jackson Json property controller
+ */
+@RequestMapping(Constants.BASE_API + "/users")
+@RestController
+public interface JacksonJsonPropertyController {
+
+    /**
+     * {@code GET  /users} : get the list of users
+     *
+     * @return the list of users.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    List<SimpleUserDto> findAll();
+}

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/jackson_json_property.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/jackson_json_property.yml
@@ -1,0 +1,41 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: JacksonJsonPropertyController
+    description: Jackson Json property controller
+paths:
+  /api/users:
+    get:
+      tags:
+        - JacksonJsonPropertyController
+      operationId: findAll
+      description: "{@code GET  /users} : get the list of users"
+      responses:
+        200:
+          description: the list of users.
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SimpleUserDto'
+components:
+  schemas:
+    SimpleUserDto:
+      description: A simple user
+      type: object
+      properties:
+        username:
+          description: User firstname
+          type: string
+        isActive:
+          description: Whether the user is active or not
+          type: boolean
+        admin:
+          description: Whether the user is an admin or not
+          type: boolean


### PR DESCRIPTION
#116 

- Ignores empty values (`@JsonProperty`)

- Does not check for potential duplicate fields, i.e:

```
public class SimpleUserDto {
    @JsonProperty("isActive")
    private boolean active;

    @JsonProperty("isActive")
    private int anotherIsActive;

    private String isActive;
}
```
which passes without error and generates an attribute of type `string`
