### PR TITLE
Support JSON spec file and fix concurrent modification exception

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
@@ -16,6 +16,9 @@ public class ApiConfiguration extends CommonApiConfiguration {
 	@Parameter
 	private String filename = "spec-open-api.yml";
 
+	@Parameter(defaultValue = "yaml")
+	private String fileFormat;
+
 	protected String baseFreeField;
 	@Parameter
 	private boolean mergeFreeFields;
@@ -36,6 +39,14 @@ public class ApiConfiguration extends CommonApiConfiguration {
 
 	public void setFilename(final String filename) {
 		this.filename = filename;
+	}
+
+	public String getFileFormat() {
+		return fileFormat;
+	}
+
+	public void setFileFormat(String fileFormat) {
+		this.fileFormat = fileFormat;
 	}
 
 	public OperationIdHelper getOperationIdHelper() {
@@ -96,6 +107,7 @@ public class ApiConfiguration extends CommonApiConfiguration {
 
 		merged.setLocations(locations);
 		merged.setFilename(filename);
+		merged.setFileFormat(fileFormat);
 		merged.setMergeFreeFields(mergeFreeFields);
 
 		if(!tag.getSubstitutions().isEmpty()) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
@@ -8,16 +8,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 public class ApiConfiguration extends CommonApiConfiguration {
 
+	private static final String DEFAULT_FILENAME = "spec-open-api.yml";
 	/**
 	 * A list of location to find api endpoints. A location could be a class or a package
 	 */
 	@Parameter(required = true)
 	private List<String> locations;
 	@Parameter
-	private String filename = "spec-open-api.yml";
-
-	@Parameter(defaultValue = "yaml")
-	private String fileFormat;
+	private String filename = DEFAULT_FILENAME;
 
 	protected String baseFreeField;
 	@Parameter
@@ -39,14 +37,6 @@ public class ApiConfiguration extends CommonApiConfiguration {
 
 	public void setFilename(final String filename) {
 		this.filename = filename;
-	}
-
-	public String getFileFormat() {
-		return fileFormat;
-	}
-
-	public void setFileFormat(String fileFormat) {
-		this.fileFormat = fileFormat;
 	}
 
 	public OperationIdHelper getOperationIdHelper() {
@@ -86,6 +76,7 @@ public class ApiConfiguration extends CommonApiConfiguration {
 		merged.defaultProduceConsumeGuessing = copy.defaultProduceConsumeGuessing;
 		merged.pathEnhancement = copy.pathEnhancement;
 		merged.pathPrefix = copy.pathPrefix;
+		merged.fileFormat = copy.fileFormat;
 		merged.loopbackOperationName = copy.loopbackOperationName;
 		merged.operationId = copy.operationId;
 		merged.freeFields = copy.freeFields;
@@ -107,7 +98,6 @@ public class ApiConfiguration extends CommonApiConfiguration {
 
 		merged.setLocations(locations);
 		merged.setFilename(filename);
-		merged.setFileFormat(fileFormat);
 		merged.setMergeFreeFields(mergeFreeFields);
 
 		if(!tag.getSubstitutions().isEmpty()) {
@@ -130,6 +120,12 @@ public class ApiConfiguration extends CommonApiConfiguration {
 		}
 		if(pathPrefix != null) {
 			merged.setPathPrefix(pathPrefix);
+		}
+		if(fileFormat != null) {
+			merged.setFileFormat(fileFormat);
+		}
+		if("json".equals(fileFormat) && DEFAULT_FILENAME.equals(filename)){
+			merged.filename = DEFAULT_FILENAME.replace(".yml", ".json");
 		}
 		if(loopbackOperationName != null) {
 			merged.setLoopbackOperationName(loopbackOperationName);

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
@@ -53,6 +53,9 @@ public class CommonApiConfiguration {
 	@Parameter
 	protected String pathPrefix;
 
+	@Parameter(defaultValue = "yaml")
+	protected String fileFormat;
+
 	/**
 	 * If true, return a short operation name for code generation, as described here :
 	 * https://loopback.io/doc/en/lb4/Decorators_openapi.html
@@ -119,6 +122,7 @@ public class CommonApiConfiguration {
 		this.defaultProduceConsumeGuessing = commonApiConfiguration.defaultProduceConsumeGuessing;
 		this.pathEnhancement = commonApiConfiguration.pathEnhancement;
 		this.pathPrefix = commonApiConfiguration.pathPrefix;
+		this.fileFormat = commonApiConfiguration.fileFormat;
 		this.loopbackOperationName = commonApiConfiguration.loopbackOperationName;
 		this.operationId = commonApiConfiguration.operationId;
 		this.freeFields = commonApiConfiguration.freeFields;
@@ -242,6 +246,14 @@ public class CommonApiConfiguration {
 
 	public void setPathPrefix(final String pathPrefix) {
 		this.pathPrefix = pathPrefix;
+	}
+
+	public String getFileFormat() {
+		return fileFormat;
+	}
+
+	public void setFileFormat(String fileFormat) {
+		this.fileFormat = fileFormat;
 	}
 
 	public String getDefaultSuccessfulOperationDescription() {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
@@ -222,11 +222,12 @@ public class SpringMvcReader extends AstractLibraryReader {
 
 		// Last case, some Dto fields can be binded to QueryParams : http://dolszewski.com/spring/how-to-bind-requestparam-to-object/
 		// Since this functionality is not well documented, it can be for now a subset of the complete functionality
+		final Map<String, ParameterObject> unnestedParams = new LinkedHashMap<>(parameters);
 		parameters.values().stream().filter(x -> x.getLocation() == null && parameterObjectBindableToQueryParams(x)).forEach(paramObj -> {
-			bindDtoToQueryParams(parameters, paramObj);
+			bindDtoToQueryParams(unnestedParams, paramObj);
 		});
 
-		return parameters.values().stream().filter(x -> x.getLocation() != null).collect(Collectors.toList());
+		return unnestedParams.values().stream().filter(x -> x.getLocation() != null).collect(Collectors.toList());
 	}
 
 	private static boolean parameterObjectBindableToQueryParams(final ParameterObject paramObj) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -54,13 +54,13 @@ import org.apache.maven.project.MavenProject;
 
 public class YamlWriter {
 
-	private static final ObjectMapper om = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-		.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR));
 	private static final String SERVERS_FIELD = "servers";
 	private static final String SECURITY_FIELD = "security";
 	private static final String EXTERNAL_DOC_FIELD = "externalDocs";
+	private static final String FILEFORMAT_JSON = "json";
 	private final Log logger = Logger.INSTANCE.getLogger();
 
+	private final ObjectMapper om;
 	private final ApiConfiguration apiConfiguration;
 
 	private final MavenProject mavenProject;
@@ -71,6 +71,8 @@ public class YamlWriter {
 	public YamlWriter(final MavenProject mavenProject, final ApiConfiguration apiConfiguration) {
 		this.apiConfiguration = apiConfiguration;
 		this.mavenProject = mavenProject;
+		this.om = apiConfiguration.getFileFormat() == FILEFORMAT_JSON ? new ObjectMapper() : new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+				.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR));
 	}
 
 	private void populateSpecificationFreeFields(final Specification specification, final Optional<JsonNode> freefields) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -2,6 +2,7 @@ package io.github.kbuntrock.yaml;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.github.javaparser.javadoc.JavadocBlockTag;
@@ -71,8 +72,10 @@ public class YamlWriter {
 	public YamlWriter(final MavenProject mavenProject, final ApiConfiguration apiConfiguration) {
 		this.apiConfiguration = apiConfiguration;
 		this.mavenProject = mavenProject;
-		this.om = apiConfiguration.getFileFormat() == FILEFORMAT_JSON ? new ObjectMapper() : new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-				.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR));
+		this.om = FILEFORMAT_JSON.equals(apiConfiguration.getFileFormat()) ?
+				new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT) :
+				new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+						.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR));
 	}
 
 	private void populateSpecificationFreeFields(final Specification specification, final Optional<JsonNode> freefields) {

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
@@ -51,6 +51,7 @@ import io.github.kbuntrock.resources.endpoint.number.NumberController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementOneController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementTwoController;
 import io.github.kbuntrock.resources.endpoint.queryparam.QueryParamDtoBindingController;
+import io.github.kbuntrock.resources.endpoint.queryparam.QueryParamFlatMixNestedDtoBindingController;
 import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveDtoController;
 import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveInterfaceDtoController;
 import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveInterfaceListDtoInParameterController;
@@ -818,6 +819,19 @@ public class SpringClassAnalyserTest extends AbstractTest {
 
 		final List<File> generated = mojo.documentProject();
 		checkGenerationResult("ut/SpringClassAnalyserTest/query_param_dto_binding.yml", generated.get(0));
+	}
+
+	@Test
+	public void query_param_flat_mix_nested_dto_binding() throws MojoFailureException, IOException, MojoExecutionException {
+
+		final DocumentationMojo mojo = createBasicMojo(QueryParamFlatMixNestedDtoBindingController.class.getCanonicalName());
+		final JavadocConfiguration javadocConfig = new JavadocConfiguration();
+		javadocConfig.setScanLocations(Arrays.asList("src/test/java/io/github/kbuntrock/resources/endpoint/queryparam",
+				"src/test/java/io/github/kbuntrock/resources/dto"));
+		mojo.setJavadocConfiguration(javadocConfig);
+
+		final List<File> generated = mojo.documentProject();
+		checkGenerationResult("ut/SpringClassAnalyserTest/query_param_flat_mix_nested_binding.yml", generated.get(0));
 	}
 
 	@Test

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/QueryParamFlatMixNestedDtoBindingController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/QueryParamFlatMixNestedDtoBindingController.java
@@ -1,0 +1,20 @@
+package io.github.kbuntrock.resources.endpoint.queryparam;
+
+import io.github.kbuntrock.resources.dto.TimeDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * @author Kévin Buntrock
+ */
+@RequestMapping("api")
+public interface QueryParamFlatMixNestedDtoBindingController {
+
+	@GetMapping("is-time-valid")
+	boolean isTimeValid(
+			@RequestParam(value = "queryString", required = false) String queryString,
+			TimeDto time,
+			@RequestParam(value = "page", required = false, defaultValue = "0") final int page);
+
+}

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/query_param_flat_mix_nested_binding.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/query_param_flat_mix_nested_binding.yml
@@ -1,0 +1,55 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: QueryParamFlatMixNestedDtoBindingController
+paths:
+  /api/is-time-valid:
+    get:
+      tags:
+        - QueryParamFlatMixNestedDtoBindingController
+      operationId: isTimeValid
+      parameters:
+        - name: queryString
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: instant
+          description: The instant field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: date
+          description: The date field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: dateTime
+          description: The date time field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: boolean


### PR DESCRIPTION
Add an option to output the spec file as a json file.

We have some existing tooling that requires the spec to be in json format.