### PR TITLE
chore: configure language level of javaparser to BLEEDING_EDGE

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocParser.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/javadoc/JavadocParser.java
@@ -48,7 +48,7 @@ public class JavadocParser {
 		this.filesToScan = filesToScan;
 		final ParserConfiguration parserConfiguration = new ParserConfiguration();
 
-		parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_18);
+		parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.BLEEDING_EDGE);
 
 		Charset charset = StandardCharsets.UTF_8;
 		if(Charset.isSupported(javadocConfiguration.getEncoding())) {


### PR DESCRIPTION
This should avoid parsing errors/warnings of projects using java 21 or superior.