### PR TITLE
chore: enable dependabot for maven dependencies of openapi-maven-plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 # Configure the github "dependabot" for :
 #  - Disables npm security scan (the angular sample projet does not need security updates since it is not part of the product)
+#  - Enables updates for the maven dependencies
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/something-not-existing"
+  - package-ecosystem: "maven"
+    directory: "/openapi-maven-plugin"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Keeping dependencies updated is usually a good practice, at least on the maven plugin itself. 