### PR TITLE
Enable upload of multiple named files in form data

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/JakartaRsReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/JakartaRsReader.java
@@ -191,12 +191,7 @@ public class JakartaRsReader extends AstractLibraryReader {
 				final MergedAnnotation requestParamMA = mergedAnnotations.get(
 					ClassLoaderUtils.getByNameRuntimeEx("jakarta.ws.rs.QueryParam"));
 				if(requestParamMA.isPresent()) {
-
-					final boolean isMultipartFile = MultipartFile.class == paramObj.getJavaClass() ||
-						(OpenApiDataType.ARRAY == paramObj.getOpenApiResolvedType().getType()
-							&& MultipartFile.class == paramObj.getArrayItemDataObject().getJavaClass());
-					if(isMultipartFile) {
-						// MultipartFile parameters are considered as a requestBody)
+					if(paramObj.isMultipartFile()) {
 						paramObj.setLocation(ParameterLocation.BODY);
 					} else {
 						paramObj.setLocation(ParameterLocation.QUERY);

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/JavaxRsReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/JavaxRsReader.java
@@ -176,11 +176,7 @@ public class JavaxRsReader extends AstractLibraryReader {
 				// Detect if is a query variable
 				final MergedAnnotation<Annotation> requestParamMA = mergedAnnotations.get("javax.ws.rs.QueryParam");
 				if(requestParamMA.isPresent()) {
-
-					final boolean isMultipartFile = MultipartFile.class == paramObj.getJavaClass() ||
-						(OpenApiDataType.ARRAY == paramObj.getOpenApiResolvedType().getType()
-							&& MultipartFile.class == paramObj.getArrayItemDataObject().getJavaClass());
-					if(isMultipartFile) {
+					if(paramObj.isMultipartFile()) {
 						// MultipartFile parameters are considered as a requestBody)
 						paramObj.setLocation(ParameterLocation.BODY);
 					} else {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
@@ -196,10 +196,7 @@ public class SpringMvcReader extends AstractLibraryReader {
 				final MergedAnnotation<RequestParam> requestParamMA = mergedAnnotations.get(RequestParam.class);
 				if(requestParamMA.isPresent()) {
 					annotationFound = true;
-					final boolean isMultipartFile = MultipartFile.class == paramObj.getJavaClass() ||
-						(OpenApiDataType.ARRAY == paramObj.getOpenApiResolvedType().getType()
-							&& MultipartFile.class == paramObj.getArrayItemDataObject().getJavaClass());
-					if(isMultipartFile) {
+					if(paramObj.isMultipartFile()) {
 						// MultipartFile parameters are considered as a requestBody)
 						paramObj.setLocation(ParameterLocation.BODY);
 					} else {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/model/ParameterObject.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/model/ParameterObject.java
@@ -1,8 +1,10 @@
 package io.github.kbuntrock.model;
 
+import io.github.kbuntrock.utils.OpenApiDataType;
 import io.github.kbuntrock.utils.ParameterLocation;
 import java.lang.reflect.Type;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public class ParameterObject extends DataObject {
 
@@ -82,5 +84,11 @@ public class ParameterObject extends DataObject {
 
 	public void setJavadocFieldName(final String javadocFieldName) {
 		this.javadocFieldName = javadocFieldName;
+	}
+
+	public boolean isMultipartFile(){
+		return MultipartFile.class == getJavaClass() ||
+			(OpenApiDataType.ARRAY == getOpenApiResolvedType().getType()
+				&& MultipartFile.class == getArrayItemDataObject().getJavaClass());
 	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -305,15 +305,19 @@ public class YamlWriter {
 				final List<ParameterObject> bodies = endpoint.getParameters().stream()
 					.filter(x -> ParameterLocation.BODY == x.getLocation())
 					.collect(Collectors.toList());
-				if(bodies.size() > 1) {
+				if(bodies.size() > 1 && !isFormData(bodies)) {
 					logger.warn("More than one body is not allowed : "
 						+ endpoint.getPath() + " - " + endpoint.getType());
 				}
 				if(!bodies.isEmpty()) {
-					final ParameterObject body = bodies.get(0);
 					final RequestBody requestBody = new RequestBody();
 					operation.setRequestBody(requestBody);
-					final Content requestBodyContent = Content.fromDataObject(body);
+
+					final ParameterObject body = bodies.get(0);
+					final Content requestBodyContent = isFormData(bodies)
+					 	? Content.fromMultipartBodies(bodies)
+						: Content.fromDataObject(body);
+
 					if(body.getFormats() != null) {
 						for(final String format : body.getFormats()) {
 							requestBody.getContent().put(format, requestBodyContent);
@@ -395,6 +399,10 @@ public class YamlWriter {
 
 		}
 		return paths;
+	}
+
+	private static boolean isFormData(List<ParameterObject> bodies) {
+		return bodies.stream().allMatch(ParameterObject::isMultipartFile);
 	}
 
 	private Map<String, Object> createSchemaSection(final TagLibrary library) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Content.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Content.java
@@ -2,42 +2,31 @@ package io.github.kbuntrock.yaml.model;
 
 import io.github.kbuntrock.model.DataObject;
 import io.github.kbuntrock.model.ParameterObject;
-import io.github.kbuntrock.utils.OpenApiDataType;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
-import org.springframework.web.multipart.MultipartFile;
+import java.util.stream.Collectors;
 
 public class Content {
-
 	private Schema schema;
 
-	public static Content fromDataObject(final ParameterObject parameterObject) {
+	public static Content fromMultipartBodies(final List<ParameterObject> parameterObjects){
+		final Content content = new Content();
 
-		final Content content = fromDataObject((DataObject) parameterObject);
+		content.schema = new Schema();
+		content.schema.setType(OpenApiTypeResolver.OBJECT_TYPE);
+		content.schema.setRequired(
+			parameterObjects.stream()
+				.filter(ParameterObject::isRequired)
+				.map(ParameterObject::getName)
+				.collect(Collectors.toList()));
 
-		final boolean isMultipartFile = MultipartFile.class == parameterObject.getJavaClass() ||
-			(OpenApiDataType.ARRAY == parameterObject.getOpenApiResolvedType().getType()
-				&& MultipartFile.class == parameterObject.getArrayItemDataObject().getJavaClass());
+		content.schema.properties = parameterObjects.stream()
+			.collect(Collectors.toMap(
+				ParameterObject::getName,
+				po-> new Property(fromDataObject((DataObject) po).schema)));
 
-		if(isMultipartFile) {
-			// the MultipartFile must be named in the body.
-			final Content multipartContent = new Content();
-			final Schema schema = new Schema();
-			multipartContent.schema = schema;
-			if(parameterObject.isRequired()) {
-				schema.setRequired(Collections.singletonList(parameterObject.getName()));
-			}
-			schema.setType(OpenApiTypeResolver.OBJECT_TYPE);
-			final Map<String, Property> propertyMap = new LinkedHashMap<>();
-			schema.setProperties(propertyMap);
-			final Property property = new Property(content.getSchema());
-			propertyMap.put(parameterObject.getName(), property);
-			return multipartContent;
-		}
 		return content;
 	}
 
@@ -54,5 +43,4 @@ public class Content {
 	public Schema getSchema() {
 		return schema;
 	}
-
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/file/FileUploadController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/file/FileUploadController.java
@@ -38,6 +38,17 @@ public interface FileUploadController {
 	String uploadSingleFile(@RequestParam long myId, @RequestParam(name = "file") MultipartFile file);
 
 	/**
+	 * Upload plusieurs fichiers nommés
+	 *
+	 * @param myId  id sous lequel sauvegarder ces fichiers
+	 * @param file fichiers à sauvegarder
+	 * @param checksumFile le fichier contenant la somme de contrôle
+	 */
+	@PostMapping(path = "named-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	String uploadNamedFiles(@RequestParam long myId, @RequestParam(name = "file") MultipartFile file, @RequestParam(name = "checksumFile")
+		MultipartFile checksumFile);
+
+	/**
 	 * Upload de fichier mais le fichier n'est pas requis ...
 	 *
 	 * @param myId

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.file_upload.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.file_upload.approved.txt
@@ -42,6 +42,40 @@ paths:
                 type: array
                 items:
                   type: string
+  /api/file-upload/named-files:
+    post:
+      tags:
+        - FileUploadController
+      operationId: uploadNamedFiles
+      parameters:
+        - name: myId
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+                - checksumFile
+              type: object
+              properties:
+                checksumFile:
+                  type: string
+                  format: binary
+                file:
+                  type: string
+                  format: binary
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: string
   /api/file-upload/non-required-files:
     post:
       tags:


### PR DESCRIPTION
When I added this maven plugin to our existing project, I noticed, that file uploads weren't correctly added to the spec file. It worked for one file or for an array of files but not for multiple files with different names.

This MR fixes this issue and lists all files in the yaml spec.