### PR TITLE
Add ability to run simple usescases from the commandline

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
@@ -56,7 +56,7 @@ public class DocumentationMojo extends AbstractMojo {
 	/**
 	 * A list of api configurations
 	 */
-	@Parameter(required = true)
+	@Parameter
 	private List<ApiConfiguration> apis;
 
 	@Parameter(property = "apiList")

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/DocumentationMojo.java
@@ -58,6 +58,9 @@ public class DocumentationMojo extends AbstractMojo {
 	 */
 	@Parameter(required = true)
 	private List<ApiConfiguration> apis;
+
+	@Parameter(property = "apiList")
+	private List<String> apiList;
 	/**
 	 * A list of api configurations
 	 */
@@ -118,6 +121,16 @@ public class DocumentationMojo extends AbstractMojo {
 	}
 
 	private void validateConfiguration() throws MojoFailureException {
+
+		if (apiList != null && !apiList.isEmpty()) {
+			if (this.apis == null) {
+				this.apis = new ArrayList<>();
+			}
+			for (final String api : apiList) {
+				this.apis.add(new ApiConfiguration(api));
+			}
+		}
+
 		if(apis == null || apis.isEmpty()) {
 			throw new MojoFailureException("At least one api configuration element should be configured");
 		}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
@@ -8,6 +8,13 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 public class ApiConfiguration extends CommonApiConfiguration {
 
+	public ApiConfiguration() {}
+
+	public ApiConfiguration(String location) {
+		this.locations = new ArrayList<>();
+		this.locations.add(location);
+	}
+
 	private static final String DEFAULT_FILENAME = "spec-open-api.yml";
 	/**
 	 * A list of location to find api endpoints. A location could be a class or a package


### PR DESCRIPTION
This adds the ability to run the plugin for simple usescases (only specifying a list of api locations) directly from the commandline. This makes including this plugin in a cicd environment much easier than having to add it to pom's, we have about 200 apps we don't want to update.. :)