### PR TITLE
Add openapi Parameter annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ openapi-maven-plugin/src/test/resources/**/*.received.txt
 !.idea/runConfigurations/
 !.idea/codeStyles
 !.idea/saveactions_settings.xml
+*.prefs
+*.classpath
+*.project

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
@@ -213,7 +213,7 @@ public abstract class AstractLibraryReader {
 	
 	protected void setSwaggerAnnotatedParameterProperties(final Parameter javaParameter, final MergedAnnotations mergedAnnotations, ParameterObject parameter){
         MergedAnnotation<Annotation> parameterAnn = mergedAnnotations.get("io.swagger.v3.oas.annotations.Parameter");
-        if (parameterAnn.isPresent() && !"".equals(parameterAnn.getString("name"))) {
+        if (parameterAnn.isPresent()) {
             String description = parameterAnn.getString("description");
             parameter.setDescription(description);
             String name = parameterAnn.getString("name");

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
@@ -10,6 +10,7 @@ import io.github.kbuntrock.model.annotation.OperationResponse;
 import io.github.kbuntrock.reflection.GenericityResolver;
 import io.github.kbuntrock.utils.Logger;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
+import io.github.kbuntrock.utils.ParameterLocation;
 import io.github.kbuntrock.utils.UnwrappingType;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -206,15 +207,20 @@ public abstract class AstractLibraryReader {
 				parameterObjects.add(paramObj);
 			}
 		}
-
+		
 		if (parameterObjects.size() > 0) endpoint.setParameters(parameterObjects);
 	}
 	
 	protected void setSwaggerAnnotatedParameterProperties(final Parameter javaParameter, final MergedAnnotations mergedAnnotations, ParameterObject parameter){
-		// TODO : add code here for handling swagger @Parameter annotation
-		// javaParameter is the java original parameter
-		// you'll find in mergedAnnotations is a helper to find annotations on the javaParameter
-		// and parameter is the object you want to mutate to add / replace informations.
+        MergedAnnotation<Annotation> parameterAnn = mergedAnnotations.get("io.swagger.v3.oas.annotations.Parameter");
+        if (parameterAnn.isPresent() && !"".equals(parameterAnn.getString("name"))) {
+            String description = parameterAnn.getString("description");
+            parameter.setDescription(description);
+            String name = parameterAnn.getString("name");
+            parameter.setName(name);
+            logger.debug("Found @Parameter " + name
+                + " param '" + parameter.getName() + "' : " + description);
+        }
 	}
 	
 	

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
@@ -122,6 +122,8 @@ public abstract class AstractLibraryReader {
 	}
 
 	protected void setSwaggerAnnotatedEndpointProperties(final Endpoint endpoint, final MergedAnnotations mergedAnnotations){
+		ArrayList<ParameterObject> parameterObjects = new ArrayList<ParameterObject>();
+
 		final MergedAnnotation<Annotation> operationAnnotation = mergedAnnotations.get("io.swagger.v3.oas.annotations.Operation");
 		if(operationAnnotation.isPresent()) {
 			OperationAnnotationInfo operationInfo = endpoint.getOperationAnnotationInfo();
@@ -140,6 +142,9 @@ public abstract class AstractLibraryReader {
 				operationInfo.setDescription(description);
 			}
 
+			MergedAnnotation<Annotation>[] parametersArray = operationAnnotation.getAnnotationArray("parameters", Annotation.class);
+			addParameters(parameterObjects, parametersArray);
+			
 			MergedAnnotation<Annotation>[] responseArray = operationAnnotation.getAnnotationArray("responses", Annotation.class);
 
 			for (MergedAnnotation<Annotation> responseAnnotation : responseArray) {
@@ -184,28 +189,10 @@ public abstract class AstractLibraryReader {
 		}
 
 		
-		ArrayList<ParameterObject> parameterObjects = new ArrayList<ParameterObject>();
-
 		final MergedAnnotation<Annotation> parametersAnnotation = mergedAnnotations.get("io.swagger.v3.oas.annotations.Parameters");
 		if(parametersAnnotation.isPresent()) {
 			MergedAnnotation<Annotation>[] parametersArray = parametersAnnotation.getAnnotationArray("value", Annotation.class);
-			for (MergedAnnotation<Annotation>parameterAnnotation : parametersArray) {
-				final String paramName = parameterAnnotation.getString("name");
-				final String paramIn = parameterAnnotation.getValue("in").orElse(null).toString();
-				final String paramDescription = parameterAnnotation.getString("description");
-				final Boolean paramRequired = parameterAnnotation.getBoolean("required");
-	            MergedAnnotation<Annotation> schemaAnn = parameterAnnotation.getAnnotation("schema", Annotation.class);
-	            final String paramType = (schemaAnn != null) ? schemaAnn.getString("type") : null;
-				final String paramExample = parameterAnnotation.getString("example");
-				
-				ParameterObject paramObj = new ParameterObject(paramName, mapSchemaTypeToJavaType(paramType), openApiTypeResolver);
-				paramObj.setLocation(ParameterLocation.fromValue("".equals(paramIn) ? "query" : paramIn));
-				paramObj.setRequired(paramRequired);
-				paramObj.setDescription(paramDescription);
-				paramObj.setExample(paramExample);
-				paramObj.setSchemaReferenceName(paramExample);
-				parameterObjects.add(paramObj);
-			}
+			addParameters(parameterObjects, parametersArray);
 		}
 		
 		if (parameterObjects.size() > 0) endpoint.setParameters(parameterObjects);
@@ -223,6 +210,26 @@ public abstract class AstractLibraryReader {
         }
 	}
 	
+	private void addParameters(ArrayList<ParameterObject> parameterObjects, MergedAnnotation<Annotation>[] parametersArray) {
+		for (MergedAnnotation<Annotation>parameterAnnotation : parametersArray) {
+			final String paramName = parameterAnnotation.getString("name");
+			final String paramIn = parameterAnnotation.getValue("in").orElse(null).toString();
+			final String paramDescription = parameterAnnotation.getString("description");
+			final Boolean paramRequired = parameterAnnotation.getBoolean("required");
+            MergedAnnotation<Annotation> schemaAnn = parameterAnnotation.getAnnotation("schema", Annotation.class);
+            final String paramType = (schemaAnn != null) ? schemaAnn.getString("type") : null;
+			final String paramExample = parameterAnnotation.getString("example");
+			
+			ParameterObject paramObj = new ParameterObject(paramName, mapSchemaTypeToJavaType(paramType), openApiTypeResolver);
+			paramObj.setLocation(ParameterLocation.fromValue("".equals(paramIn) ? "query" : paramIn));
+			paramObj.setRequired(paramRequired);
+			paramObj.setDescription(paramDescription);
+			paramObj.setExample(paramExample);
+			paramObj.setSchemaReferenceName(paramExample);
+			parameterObjects.add(paramObj);
+		}
+
+	}
 	
 	private static Class<?> mapSchemaTypeToJavaType(String schemaType) {
 	    if (schemaType == null) return Object.class;

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
@@ -15,6 +15,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -56,7 +57,7 @@ public abstract class AstractLibraryReader {
 		return result;
 	}
 
-	protected DataObject readResponseObject(final Class clazz, final Method method,
+	protected DataObject readResponseObject(final Class<?> clazz, final Method method,
 		final MergedAnnotations mergedAnnotations) {
 		final Class<?> returnType = method.getReturnType();
 		if(Void.class == returnType || Void.TYPE == returnType) {
@@ -97,10 +98,10 @@ public abstract class AstractLibraryReader {
 
 	public abstract List<String> readBasePaths(final Class<?> clazz, final MergedAnnotations mergedAnnotations);
 
-	public abstract void computeAnnotations(final Class clazz, final String basePath, final Method method, final MergedAnnotations mergedAnnotations,
+	public abstract void computeAnnotations(final Class<?> clazz, final String basePath, final Method method, final MergedAnnotations mergedAnnotations,
 		final Tag tagr) throws MojoFailureException;
 
-	protected abstract List<ParameterObject> readParameters(final Class clazz, final Method originalMethod, final MergedAnnotations endpointAnnotations);
+	protected abstract List<ParameterObject> readParameters(final Class<?> clazz, final Method originalMethod, final MergedAnnotations endpointAnnotations);
 
 	protected abstract List<String> readEndpointPaths(String basePath,
 		MergedAnnotation<? extends Annotation> requestMappingMergedAnnotation);
@@ -180,12 +181,55 @@ public abstract class AstractLibraryReader {
 				operationInfo.addResponse(operationResponse);
 			}
 		}
-	}
 
+		
+		ArrayList<ParameterObject> parameterObjects = new ArrayList<ParameterObject>();
+
+		final MergedAnnotation<Annotation> parametersAnnotation = mergedAnnotations.get("io.swagger.v3.oas.annotations.Parameters");
+		if(parametersAnnotation.isPresent()) {
+			MergedAnnotation<Annotation>[] parametersArray = parametersAnnotation.getAnnotationArray("value", Annotation.class);
+			for (MergedAnnotation<Annotation>parameterAnnotation : parametersArray) {
+				final String paramName = parameterAnnotation.getString("name");
+				final String paramIn = parameterAnnotation.getValue("in").orElse(null).toString();
+				final String paramDescription = parameterAnnotation.getString("description");
+				final Boolean paramRequired = parameterAnnotation.getBoolean("required");
+	            MergedAnnotation<Annotation> schemaAnn = parameterAnnotation.getAnnotation("schema", Annotation.class);
+	            final String paramType = (schemaAnn != null) ? schemaAnn.getString("type") : null;
+				final String paramExample = parameterAnnotation.getString("example");
+				
+				ParameterObject paramObj = new ParameterObject(paramName, mapSchemaTypeToJavaType(paramType), openApiTypeResolver);
+				paramObj.setLocation(ParameterLocation.fromValue("".equals(paramIn) ? "query" : paramIn));
+				paramObj.setRequired(paramRequired);
+				paramObj.setDescription(paramDescription);
+				paramObj.setExample(paramExample);
+				paramObj.setSchemaReferenceName(paramExample);
+				parameterObjects.add(paramObj);
+			}
+		}
+
+		if (parameterObjects.size() > 0) endpoint.setParameters(parameterObjects);
+	}
+	
 	protected void setSwaggerAnnotatedParameterProperties(final Parameter javaParameter, final MergedAnnotations mergedAnnotations, ParameterObject parameter){
 		// TODO : add code here for handling swagger @Parameter annotation
 		// javaParameter is the java original parameter
 		// you'll find in mergedAnnotations is a helper to find annotations on the javaParameter
 		// and parameter is the object you want to mutate to add / replace informations.
 	}
+	
+	
+	private static Class<?> mapSchemaTypeToJavaType(String schemaType) {
+	    if (schemaType == null) return Object.class;
+
+	    switch (schemaType.trim().toLowerCase()) {
+	        case "string": return String.class;
+	        case "integer": return Integer.class;
+	        case "number": return Double.class;
+	        case "boolean": return Boolean.class;
+	        case "array": return java.util.List.class;
+	        case "object": return java.util.Map.class;
+	        default: return Object.class;
+	    }
+	}
+
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/model/ParameterObject.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/model/ParameterObject.java
@@ -13,6 +13,8 @@ public class ParameterObject extends DataObject {
 	private boolean required;
 	private boolean allowEmptyValue;
 	private ParameterLocation location;
+	private String description;
+	private String example;
 	// Set only if it is a "body" parameter : json, xml, plain text, ...
 	private List<String> formats;
 
@@ -70,6 +72,22 @@ public class ParameterObject extends DataObject {
 
 	public void setLocation(final ParameterLocation location) {
 		this.location = location;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(final String description) {
+		this.description = description;
+	}
+
+	public String getExample() {
+		return example;
+	}
+
+	public void setExample(final String example) {
+		this.example = example;
 	}
 
 	public List<String> getFormats() {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/utils/ParameterLocation.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/utils/ParameterLocation.java
@@ -1,9 +1,36 @@
 package io.github.kbuntrock.utils;
 
 public enum ParameterLocation {
-	PATH,
-	QUERY,
-	BODY,
-	HEADER,
-	BODY_PART
+    DEFAULT(""),
+    PATH("path"),
+    QUERY("query"),
+    BODY("body"),
+    HEADER("header"),
+    BODY_PART("body_part"),
+    COOKIE("cookie");
+
+	private String value;
+
+	ParameterLocation(String value) {
+		if (value == null) value = "";
+        this.value = value.trim().toLowerCase();
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+    
+    public static ParameterLocation fromValue(String value) {
+        if (value == null) {
+            return DEFAULT;
+        }
+        String normalized = value.trim().toLowerCase();
+        for (ParameterLocation loc : values()) {
+            if (loc.value.equals(normalized)) {
+                return loc;
+            }
+        }
+        return DEFAULT;
+    }
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/utils/ParameterLocation.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/utils/ParameterLocation.java
@@ -1,7 +1,6 @@
 package io.github.kbuntrock.utils;
 
 public enum ParameterLocation {
-    DEFAULT(""),
     PATH("path"),
     QUERY("query"),
     BODY("body"),
@@ -23,7 +22,7 @@ public enum ParameterLocation {
     
     public static ParameterLocation fromValue(String value) {
         if (value == null) {
-            return DEFAULT;
+            return QUERY;
         }
         String normalized = value.trim().toLowerCase();
         for (ParameterLocation loc : values()) {
@@ -31,6 +30,6 @@ public enum ParameterLocation {
                 return loc;
             }
         }
-        return DEFAULT;
+        return QUERY;
     }
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -44,8 +44,10 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+
 
 public class YamlWriter {
 
@@ -295,7 +297,7 @@ public class YamlWriter {
 					}
 
 					// Javadoc handling
-					if(methodJavadoc != null) {
+					if(StringUtils.isEmpty(parameterElement.getDescription()) && methodJavadoc != null) {
 						final Optional<JavadocBlockTag> parameterDoc = methodJavadoc.getParamBlockTagByName(
 							parameter.getJavadocFieldName());
 						if(parameterDoc.isPresent()) {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -276,6 +276,8 @@ public class YamlWriter {
 					parameterElement.setIn(parameter.getLocation().toString().toLowerCase(Locale.ENGLISH));
 					parameterElement.setRequired(parameter.isRequired());
 					parameterElement.setAllowEmptyValue(parameter.isAllowEmptyValue());
+					parameterElement.setDescription(parameter.getDescription());
+					parameterElement.setExample(parameter.getExample());
 
 					final Property schema = new Property(Content.fromDataObject(parameter, tagLibrary).getSingleSchema());
 

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/ParameterElement.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/ParameterElement.java
@@ -10,6 +10,8 @@ public class ParameterElement {
 	private String summary;
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private String description;
+	@JsonInclude(Include.NON_NULL)
+	private String example;
 	private String in;
 	private boolean required;
 	@JsonInclude(Include.NON_DEFAULT)
@@ -71,5 +73,13 @@ public class ParameterElement {
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public String getExample() {
+		return example;
+	}
+
+	public void setExample(String example) {
+		this.example = example;
 	}
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SwaggerAnalyzerTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SwaggerAnalyzerTest.java
@@ -74,4 +74,13 @@ public class SwaggerAnalyzerTest extends AbstractTest {
 		mojo.setJavadocConfiguration(javadocConfiguration);
 		checkGenerationResult(mojo.documentProject());
 	}
+	
+	@Test
+	public void basicAnnotatedParametersWithReturnObjectsWithJavadoc() throws MojoFailureException, IOException, MojoExecutionException {
+		final DocumentationMojo mojo = createBasicMojo(EntityAnnotationWithParametersResource.class.getCanonicalName());
+        JavadocConfiguration javadocConfiguration = new JavadocConfiguration();
+        javadocConfiguration.setScanLocations(Collections.singletonList("src/test/java/io/github/kbuntrock/resources/endpoint/swagger"));
+        mojo.setJavadocConfiguration(javadocConfiguration);
+		checkGenerationResult(mojo.documentProject());
+	}
 }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SwaggerAnalyzerTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SwaggerAnalyzerTest.java
@@ -5,6 +5,7 @@ import io.github.kbuntrock.configuration.JavadocConfiguration;
 import io.github.kbuntrock.configuration.library.TagAnnotation;
 import io.github.kbuntrock.resources.endpoint.swagger.ApiResponseResource;
 import io.github.kbuntrock.resources.endpoint.swagger.EntityAnnotationResource;
+import io.github.kbuntrock.resources.endpoint.swagger.EntityAnnotationWithParametersResource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -52,6 +53,14 @@ public class SwaggerAnalyzerTest extends AbstractTest {
 	@Test
 	public void basicAnnotatedResponseWithReturnObjects() throws MojoFailureException, IOException, MojoExecutionException {
 		final DocumentationMojo mojo = createBasicMojo(EntityAnnotationResource.class.getCanonicalName());
+
+		checkGenerationResult(mojo.documentProject());
+
+	}
+
+	@Test
+	public void basicAnnotatedParametersWithReturnObjects() throws MojoFailureException, IOException, MojoExecutionException {
+		final DocumentationMojo mojo = createBasicMojo(EntityAnnotationWithParametersResource.class.getCanonicalName());
 
 		checkGenerationResult(mojo.documentProject());
 

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationResource.java
@@ -41,7 +41,7 @@ public class EntityAnnotationResource {
 					@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ErrorEntityWithAnnotations.class)))
 			})
 	@GetMapping("/unparametrized")
-	public ResponseEntity unparametrized() {
+	public ResponseEntity<?> unparametrized() {
 		return ResponseEntity.ok(new ResponseEntityWithAnnotations());
 	}
 

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationResource.java
@@ -41,7 +41,7 @@ public class EntityAnnotationResource {
 					@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ErrorEntityWithAnnotations.class)))
 			})
 	@GetMapping("/unparametrized")
-	public ResponseEntity<?> unparametrized() {
+	public ResponseEntity unparametrized() {
 		return ResponseEntity.ok(new ResponseEntityWithAnnotations());
 	}
 

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
@@ -1,0 +1,40 @@
+package io.github.kbuntrock.resources.endpoint.swagger;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+@RestController
+@RequestMapping("/api")
+public class EntityAnnotationWithParametersResource {
+
+
+    @Operation(summary = "Search alarms")
+    @Parameters({
+        @Parameter(name = "pv", description = "PV name", in=ParameterIn.QUERY, schema = @Schema(type = "string"), required = false, example = "*"),
+        @Parameter(name = "start", description = "Start time", schema = @Schema(type = "string"), required = false, example = "2024-06-12"),
+        @Parameter(name = "end", description = "End time", schema = @Schema(type = "string"), required = false, example = "2024-06-14"),
+    })
+    @RequestMapping(value = "/search/alarm", method = RequestMethod.GET)
+	public ResponseEntity<ResponseEntityWithAnnotations> searchAlarms() {
+		return ResponseEntity.ok(new ResponseEntityWithAnnotations());
+
+	}
+
+	@Operation(summary = "Search alarms by PV name")
+    @RequestMapping(value = "/search/alarm/pv/{pv}", method = RequestMethod.GET)
+	public ResponseEntity<ResponseEntityWithAnnotations> searchPv(@Parameter(description = "PV name", name = "pv") @PathVariable String pv) {
+		return ResponseEntity.ok(new ResponseEntityWithAnnotations());
+
+	}
+
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
@@ -18,9 +18,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class EntityAnnotationWithParametersResource {
 
 
-    @Operation(summary = "Search alarms")
+    @Operation(summary = "Search alarms",
+        parameters = {
+            @Parameter(name = "pv", description = "PV name", in=ParameterIn.QUERY, schema = @Schema(type = "string"), required = false, example = "*"),
+        }
+    )
     @Parameters({
-        @Parameter(name = "pv", description = "PV name", in=ParameterIn.QUERY, schema = @Schema(type = "string"), required = false, example = "*"),
         @Parameter(name = "start", description = "Start time", schema = @Schema(type = "string"), required = false, example = "2024-06-12"),
         @Parameter(name = "end", description = "End time", schema = @Schema(type = "string"), required = false, example = "2024-06-14"),
     })

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
@@ -1,0 +1,87 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: EntityAnnotationWithParametersResource
+paths:
+  /api/search/alarm:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchAlarms
+      summary: Search alarms
+      parameters:
+        - name: pv
+          description: PV name
+          example: '*'
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: start
+          description: Start time
+          example: 2024-06-12
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: end
+          description: End time
+          example: 2024-06-14
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+  /api/search/alarm/pv/{pv}:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchPv
+      summary: Search alarms by PV name
+      parameters:
+        - name: pv
+          description: PV name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+components:
+  schemas:
+    ResponseEntityWithAnnotations:
+      type: object
+      properties:
+        id:
+          description: Unique identifier for the response
+          type: string
+          example: 12345
+        status:
+          description: Status of the response
+          type: string
+          example: success
+        data:
+          description: Data returned in the response
+          type: string
+          example: "{\"key\":\"value\"}"
+        timestamp:
+          description: Timestamp of the collected data
+          type: string
+          format: date-time
+          example: 2023-10-01T12:00:00

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -1,0 +1,87 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: EntityAnnotationWithParametersResource
+paths:
+  /api/search/alarm:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchAlarms
+      summary: Search alarms
+      parameters:
+        - name: pv
+          description: PV name
+          example: '*'
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: start
+          description: Start time
+          example: 2024-06-12
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: end
+          description: End time
+          example: 2024-06-14
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+  /api/search/alarm/pv/{pv}:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchPv
+      summary: Search alarms by PV name
+      parameters:
+        - name: pv
+          description: PV name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+components:
+  schemas:
+    ResponseEntityWithAnnotations:
+      type: object
+      properties:
+        id:
+          description: Unique identifier for the response
+          type: string
+          example: 12345
+        status:
+          description: Status of the response
+          type: string
+          example: success
+        data:
+          description: Data returned in the response
+          type: string
+          example: "{\"key\":\"value\"}"
+        timestamp:
+          description: Timestamp of the collected data
+          type: string
+          format: date-time
+          example: 2023-10-01T12:00:00


### PR DESCRIPTION
Add openapi Parameter annotations
https://github.com/kbuntrock/openapi-maven-plugin/issues/249

The annotation @Parameter is not parsed correctly if not in an array @Parameters like in this example :
```
    @Operation(summary = "Search alarms by PV name")
    @RequestMapping(value = "/search/alarm/pv/{pv}", method = RequestMethod.GET)
    public List<AlarmLogMessage> searchPv(@Parameter(description = "PV name") @PathVariable String pv)
```
I cannot find it in MergedAnnotations mergedAnnotations parameter in the setSwaggerAnnotatedEndpointProperties method
Is there something missing in the parsing ? I'm a bit lost in your code, could you help me and tell me how I can add this particular annotation in the parsing ?

Please also check my code to be sure it uses the correct methods to map the annotations