### PR TITLE
Fix merging of possibly missing values from swagger `@Parameter` annotation

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AstractLibraryReader.java
@@ -203,10 +203,18 @@ public abstract class AstractLibraryReader {
 	protected void setSwaggerAnnotatedParameterProperties(final Parameter javaParameter, final MergedAnnotations mergedAnnotations, ParameterObject parameter){
         MergedAnnotation<Annotation> parameterAnn = mergedAnnotations.get("io.swagger.v3.oas.annotations.Parameter");
         if (parameterAnn.isPresent()) {
-            String description = parameterAnn.getString("description");
-            parameter.setDescription(description);
-            String name = parameterAnn.getString("name");
-            parameter.setName(name);
+            final String description = parameterAnn.getString("description");
+            if (StringUtils.isNotBlank(description)) {
+                parameter.setDescription(description);
+            }
+            final String name = parameterAnn.getString("name");
+            if (StringUtils.isNotBlank(name)) {
+                parameter.setName(name);
+            }
+            final String example = parameterAnn.getString("example");
+            if (StringUtils.isNotBlank(example)) {
+                parameter.setExample(example);
+            }
             context.getLogger().debug("Found @Parameter " + name
                 + " param '" + parameter.getName() + "' : " + description);
         }

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
@@ -40,4 +40,12 @@ public class EntityAnnotationWithParametersResource {
 
 	}
 
+    @Operation(summary = "Search alarms by trigger")
+    @RequestMapping(value = "/search/alarm/trigger/{trigger}", method = RequestMethod.GET)
+    public ResponseEntity<ResponseEntityWithAnnotations> searchTrigger(
+        @Parameter(description = "Trigger of the alarms", example = "rule47")
+        @PathVariable("trigger")
+        String triggerParam) {
+        return ResponseEntity.ok(new ResponseEntityWithAnnotations());
+    }
 }

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
@@ -63,6 +63,27 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+  /api/search/alarm/trigger/{trigger}:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchTrigger
+      summary: Search alarms by trigger
+      parameters:
+        - name: trigger
+          description: Trigger of the alarms
+          example: rule47
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
 components:
   schemas:
     ResponseEntityWithAnnotations:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -63,6 +63,27 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ResponseEntityWithAnnotations'
+  /api/search/alarm/trigger/{trigger}:
+    get:
+      tags:
+        - EntityAnnotationWithParametersResource
+      operationId: searchTrigger
+      summary: Search alarms by trigger
+      parameters:
+        - name: trigger
+          description: Trigger of the alarms
+          example: rule47
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ResponseEntityWithAnnotations'
 components:
   schemas:
     ResponseEntityWithAnnotations:


### PR DESCRIPTION
When using the Swagger `@Parameter` annotation to add additional information to parameters that are already annotated with, say, Spring MVC annotations, e.g. to add example values and a proper description, it is currently necessary to repeat the `name` property. 

This PR overrides the name, description and example values in the `ParameterObject` only if they are present in the `@Parameter` annotation.

Example:
```
      @Parameter(description = "Content type of the uploaded binary.", example = "image/jpeg")
      @RequestHeader(value = "Content-Type") 
      final String contentType
```

Will result in:
```
    "parameters" : [ {
          "name" : "Content-Type",
          "description" : "Content type of the uploaded binary.",
          "example" : "image/jpeg",
          "in" : "header",
          "required" : true,
          "schema" : {
            "type" : "string"
          }
    } ]
```

Use this checklist to help us review and merge your contribution quickly and smoothly:

- [x] Ensure your pull request focuses on a single issue and does not introduce unrelated changes.
- [x] Provide a clear and detailed enough description explaining what the pull request does, how, and why.
- [x] Add unit tests that reflect any behavioral changes, making sure they fail when the corresponding runtime modifications are not applied.
- [x] Run `mvn verify` to confirm that the basic checks pass.
  A more thorough validation will be executed automatically on your pull request.
- [ ] Update the documentation if required (at least the English version).
  English documentation files can be found in `docs/docs`.
