### PR TITLE
Bug fix release was breaking jdk25 IT

### DIFF
--- a/integration-tests/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case_jdk25/pom.xml
+++ b/integration-tests/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case_jdk25/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-        <openapi-plugin-project-version>0.0.29-SNAPSHOT</openapi-plugin-project-version>
+        <openapi-plugin-project-version>0.0.30-SNAPSHOT</openapi-plugin-project-version>
 
     </properties>
 

--- a/integration-tests/src/test/resources-its/io/github/kbuntrock/it/pom.xml
+++ b/integration-tests/src/test/resources-its/io/github/kbuntrock/it/pom.xml
@@ -15,6 +15,7 @@
         <module>BasicIT/nominal_test_case_jdk11</module>
         <module>BasicIT/nominal_test_case_jdk17</module>
 		<module>BasicIT/nominal_test_case_jdk21</module>
+		<module>BasicIT/nominal_test_case_jdk25</module>
     </modules>
 
 


### PR DESCRIPTION
Releasing was not updating the openapi-maven-plugin used in the integration test for jdk 25.
Therefore it was KO after the release.

Use this checklist to help us review and merge your contribution quickly and smoothly:

- [x] Ensure your pull request focuses on a single issue and does not introduce unrelated changes.
- [x] Provide a clear and detailed enough description explaining what the pull request does, how, and why.
- [x] Add unit tests that reflect any behavioral changes, making sure they fail when the corresponding runtime modifications are not applied.
- [x] Run `mvn verify` to confirm that the basic checks pass.
  A more thorough validation will be executed automatically on your pull request.
- [x] Update the documentation if required (at least the English version).
  English documentation files can be found in `docs/docs`.
