### PR TITLE
use project description from POM in OpenAPI specs

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -7,12 +7,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.github.javaparser.javadoc.JavadocBlockTag;
-import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.MojoRuntimeException;
 import io.github.kbuntrock.TagLibrary;
 import io.github.kbuntrock.configuration.ApiConfiguration;
 import io.github.kbuntrock.configuration.parser.CommonParserUtils;
 import io.github.kbuntrock.configuration.parser.JsonParserUtils;
+import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.javadoc.ClassDocumentation;
 import io.github.kbuntrock.javadoc.ClassDocumentation.EnhancementType;
 import io.github.kbuntrock.javadoc.JavadocWrapper;
@@ -21,7 +21,6 @@ import io.github.kbuntrock.model.Endpoint;
 import io.github.kbuntrock.model.ParameterObject;
 import io.github.kbuntrock.model.Tag;
 import io.github.kbuntrock.model.annotation.OperationResponse;
-import io.github.kbuntrock.reflection.AdditionnalSchemaLibrary;
 import io.github.kbuntrock.utils.ObjectsUtils;
 import io.github.kbuntrock.utils.OpenApiConstants;
 import io.github.kbuntrock.utils.OpenApiDataType;
@@ -38,14 +37,26 @@ import io.github.kbuntrock.yaml.model.Schema;
 import io.github.kbuntrock.yaml.model.Server;
 import io.github.kbuntrock.yaml.model.Specification;
 import io.github.kbuntrock.yaml.model.TagElement;
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class YamlWriter {
 
@@ -121,7 +132,8 @@ public class YamlWriter {
 		}
 
 		final Specification specification = new Specification();
-		final Info info = new Info(context.getProject().getName(), context.getProject().getVersion(), freefields);
+		final Info info = new Info(context.getProject().getName(), context.getProject().getVersion(),
+			context.getProject().getDescription(), freefields);
 		specification.setInfo(info);
 
 		populateSpecificationFreeFields(specification, freefields);

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Info.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Info.java
@@ -3,6 +3,7 @@ package io.github.kbuntrock.yaml.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import java.util.Optional;
 
 public class Info {
@@ -21,9 +22,10 @@ public class Info {
 	private Object license;
 	private String version;
 
-	public Info(String title, String version, Optional<JsonNode> freefields) {
+	public Info(String title, String version, String description, Optional<JsonNode> freefields) {
 		this.title = title;
 		this.version = version;
+		this.description = description;
 		if(freefields.isPresent() && freefields.get().get(INFO_FIELD) != null) {
 			JsonNode infos = freefields.get().get(INFO_FIELD);
 			if(infos.get("title") != null) {

--- a/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case/pom.xml
+++ b/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case/pom.xml
@@ -7,6 +7,7 @@
     <groupId>io.github.kbuntrock.openapi.it</groupId>
     <version>23.5.2</version>
     <name>Basic integration test</name>
+    <description>Basic description test</description>
 
     <properties>
         <java.version>17</java.version>

--- a/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/sealed_class/pom.xml
+++ b/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/sealed_class/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>openapi-sealed-class-it</artifactId>
     <version>1.0.0</version>
     <name>Basic integration test</name>
-
+    <description>Basic description test</description>
     <properties>
         <java.version>17</java.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>

--- a/openapi-maven-plugin/src/test/resources/it/BasicIT/sealed_class.yml
+++ b/openapi-maven-plugin/src/test/resources/it/BasicIT/sealed_class.yml
@@ -2,6 +2,7 @@
 openapi: 3.0.3
 info:
   title: Basic integration test
+  description: Basic description test
   version: 1.0.0
 servers:
   - url: ""


### PR DESCRIPTION
This PR enhances the OpenAPI specification generation by automatically pulling the description field from the project's pom.xml.
It ensures consistency between the project documentation and the generated API specifications, reducing manual updates and keeping the pom.xml as the single source of truth for project metadata.

I have run all the tests with positive results
