### PR TITLE
support example fallback from Parameter to Schema

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AbstractLibraryReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/AbstractLibraryReader.java
@@ -269,8 +269,10 @@ public abstract class AbstractLibraryReader {
 			final Boolean paramRequired = parameterAnnotation.getBoolean("required");
 			MergedAnnotation schemaAnn = parameterAnnotation.getAnnotation("schema");
 			final String paramType = (schemaAnn != null) ? schemaAnn.getString("type") : null;
-			final String paramExample = parameterAnnotation.getString("example");
-
+			// Priority: @Parameter(example) > @Schema(example) per OpenAPI 3 Specs
+			final String paramExample = Optional.ofNullable(parameterAnnotation.getString("example"))
+				.filter(e -> !e.isEmpty())
+				.orElseGet(() -> schemaAnn != null ? schemaAnn.getString("example") : null);
 			ParameterObject paramObj = new ParameterObject(paramName, mapSchemaTypeToJavaType(paramType), openApiTypeResolver);
 			paramObj.setLocation(ParameterLocation.fromValue("".equals(paramIn) ? "query" : paramIn));
 			paramObj.setRequired(paramRequired);

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/swagger/EntityAnnotationWithParametersResource.java
@@ -20,11 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class EntityAnnotationWithParametersResource {
 
 	@Operation(summary = "Search alarms", parameters = {
-			@Parameter(name = "pv", description = "PV name", in = ParameterIn.QUERY, schema = @Schema(type = "string"), required = false, example = "*"),
+			@Parameter(name = "pv", description = "PV name", in = ParameterIn.QUERY, schema = @Schema(type = "string", example = "*"), required = false),
 	})
 	@Parameters({
 			@Parameter(name = "start", description = "Start time", schema = @Schema(type = "string"), required = false, example = "2024-06-12"),
-			@Parameter(name = "end", description = "End time", schema = @Schema(type = "string"), required = false, example = "2024-06-14"),
+			@Parameter(name = "end", description = "End time", schema = @Schema(type = "string", example = "ignored"), required = false, example = "2024-06-14"),
 	})
 	@RequestMapping(value = "/search/alarm", method = RequestMethod.GET)
 	@GET


### PR DESCRIPTION
This PR improves the example resolution logic for parameters. Previously, the plugin only looked for the `example` field directly within the `@Parameter` annotation, completely ignoring any `example` defined inside the `@Schema` annotation.

The `example` can be defined in both locations. While the `@Parameter` level has higher priority, the `@Schema` level should serve as the default fallback if the former is not provided.

This change ensures that:
1. first check on `@Parameter(example = "...")`
2. if no `example` is found at the parameter level, it now correctly falls back to `@Schema(example = "...")`.
