### PR TITLE
Do not inherit parent project "description"

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -581,6 +581,13 @@ components:
 
 Value to use for the enumeration description extension.
 
+### useProjectDescription
+
+- Type : `boolean`
+- Default value: `false`
+
+Use the maven project description as the OpenAPI doc description. The description is inherited from parent pom.xml if not locally defined.
+
 ## javadocConfiguration
 
 - Type: `section`

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/configuration.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/configuration.md
@@ -581,6 +581,13 @@ components:
 
 Valeur à utiliser pour l’extension des descriptions d’énumération.
 
+### useProjectDescription
+
+- Type : `boolean`
+- Valeur par défaut : `false`
+
+Utilise la description du projet maven en tant que description de la doc OpenAPI. La description est héritée des parents si non définie localement.
+
 ## javadocConfiguration
 
 - Type: `balise de section`

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/ApiConfiguration.java
@@ -88,6 +88,7 @@ public class ApiConfiguration extends CommonApiConfiguration {
 		merged.nonNullableAnnotation = copy.nonNullableAnnotation;
 		merged.nullableAnnotation = copy.nullableAnnotation;
 		merged.nonDocumentableParameterClasses = copy.nonDocumentableParameterClasses;
+		merged.useProjectDescription = copy.useProjectDescription;
 		// End copy properties
 
 		merged.setFilename(filename);
@@ -204,6 +205,9 @@ public class ApiConfiguration extends CommonApiConfiguration {
 		}
 		if(nonDocumentableParameterClasses != null) {
 			merged.setNonDocumentableParameterClasses(nonDocumentableParameterClasses);
+		}
+		if(useProjectDescription != null) {
+			merged.setUseProjectDescription(useProjectDescription);
 		}
 		return merged;
 	}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/CommonApiConfiguration.java
@@ -148,6 +148,12 @@ public class CommonApiConfiguration {
 	@Parameter
 	protected List<String> nonDocumentableParameterClasses = new ArrayList<>();
 
+	/**
+	 * If true, inject the pom.xml description (potentially inherited from parents) in the openAPi documentation.
+	 */
+	@Parameter
+	protected Boolean useProjectDescription;
+
 	public CommonApiConfiguration() {
 	}
 
@@ -180,6 +186,7 @@ public class CommonApiConfiguration {
 		this.defaultNonNullableFields = commonApiConfiguration.defaultNonNullableFields;
 		this.nonNullableAnnotation = commonApiConfiguration.nonNullableAnnotation;
 		this.nullableAnnotation = commonApiConfiguration.nullableAnnotation;
+		this.useProjectDescription = commonApiConfiguration.useProjectDescription;
 		for(final String tagAnnotation : commonApiConfiguration.tagAnnotations) {
 			this.tagAnnotations.add(tagAnnotation);
 		}
@@ -202,9 +209,7 @@ public class CommonApiConfiguration {
 		if(!commonApiConfiguration.extraSchemaClasses.isEmpty()) {
 			this.extraSchemaClasses.addAll(commonApiConfiguration.extraSchemaClasses);
 		}
-		for(final String nonDocumentableParameterClass : commonApiConfiguration.nonDocumentableParameterClasses) {
-			this.nonDocumentableParameterClasses.add(nonDocumentableParameterClass);
-		}
+		this.nonDocumentableParameterClasses.addAll(commonApiConfiguration.nonDocumentableParameterClasses);
 	}
 
 	public void initDefaultValues() {
@@ -255,6 +260,9 @@ public class CommonApiConfiguration {
 		}
 		if(attachArtifact == null) {
 			attachArtifact = true;
+		}
+		if(useProjectDescription == null) {
+			useProjectDescription = false;
 		}
 	}
 
@@ -496,5 +504,13 @@ public class CommonApiConfiguration {
 
 	public void setNonDocumentableParameterClasses(final List<String> nonDocumentableParameterClasses) {
 		this.nonDocumentableParameterClasses = nonDocumentableParameterClasses;
+	}
+
+	public Boolean getUseProjectDescription() {
+		return useProjectDescription;
+	}
+
+	public void setUseProjectDescription(Boolean useProjectDescription) {
+		this.useProjectDescription = useProjectDescription;
 	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -118,7 +118,7 @@ public class YamlWriter {
 
 		final Specification specification = new Specification();
 		final Info info = new Info(context.getProject().getName(), context.getProject().getVersion(),
-			context.getProject().getOriginalModel() == null ? null : context.getProject().getOriginalModel().getDescription(),
+			apiConfiguration.getUseProjectDescription() ? context.getProject().getDescription() : null,
 			freefields);
 		specification.setInfo(info);
 

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -118,7 +118,8 @@ public class YamlWriter {
 
 		final Specification specification = new Specification();
 		final Info info = new Info(context.getProject().getName(), context.getProject().getVersion(),
-			context.getProject().getDescription(), freefields);
+			context.getProject().getOriginalModel() == null ? null : context.getProject().getOriginalModel().getDescription(),
+			freefields);
 		specification.setInfo(info);
 
 		populateSpecificationFreeFields(specification, freefields);

--- a/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case/pom.xml
+++ b/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case/pom.xml
@@ -58,6 +58,7 @@
                         <defaultErrors>openapi/default_errors.json</defaultErrors>
                         <loopbackOperationName>false</loopbackOperationName>
                         <operationId>{method_name}</operationId>
+                        <useProjectDescription>true</useProjectDescription>
                         <tagAnnotations>
                             <annotation>RequestMapping</annotation>
                         </tagAnnotations>

--- a/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case_jaxrs/pom.xml
+++ b/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/nominal_test_case_jaxrs/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>openapi-basic-it-jaxrs</artifactId>
     <version>23.5.2</version>
     <name>Basic integration test Jax-RS</name>
+    <description>Basic description test</description>
 
     <properties>
         <java.version>17</java.version>

--- a/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/sealed_class/pom.xml
+++ b/openapi-maven-plugin/src/test/resources-its/io/github/kbuntrock/it/BasicIT/sealed_class/pom.xml
@@ -60,6 +60,7 @@
                             <locations>
                                 <location>io.github.kbuntrock.sample.enpoint</location>
                             </locations>
+                            <useProjectDescription>true</useProjectDescription>
                         </api>
                     </apis>
                     <javadocConfiguration>


### PR DESCRIPTION
Hello @patred ,

While testing this version of the plugin on a project, I realised that `project.getDescription()` inherits the description from the nearest parent description, which did not make much sense for my project.

The “original model” corresponds to the model without inheritance, which seems more relevant to me—hence this MR.

Does that sound okay to you?