### PR TITLE
Improve @ModelAttribute support

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/TagLibrary.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/TagLibrary.java
@@ -1,13 +1,11 @@
 package io.github.kbuntrock;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import io.github.kbuntrock.configuration.ApiConfiguration;
+import io.github.kbuntrock.configuration.library.reader.BeanDefinitionUtils;
 import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.javadoc.ClassDocumentation;
 import io.github.kbuntrock.model.*;
 import io.github.kbuntrock.model.annotation.OperationResponse;
-import io.github.kbuntrock.reflection.BeanDefinition;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
 import io.github.kbuntrock.yaml.model.ChildObject;
 
@@ -167,7 +165,7 @@ public class TagLibrary {
 			return;
 		}
 		safeLogObjectInspection(explored);
-		List<ChildObject> childProperties = getPropertyObjectsToDocument(explored);
+		List<ChildObject> childProperties = BeanDefinitionUtils.getPropertyObjectsToDocument(explored, context);
 		for(ChildObject child : childProperties) {
 			if(child.getBeanDefinition().compatibleWithFlow(explored.getFlow())) {
 				exploreDataObject(child.getDataObject());
@@ -210,29 +208,6 @@ public class TagLibrary {
 			context.getLogger().error("Cannot log object inspection", e);
 		}
 
-	}
-
-	public List<ChildObject> getPropertyObjectsToDocument(DataObject explored) {
-		List<BeanDefinition> propertyDefinitions = getPropertyDefinitions(context.getSchemaObjectMapper(),
-			explored);
-		List<ChildObject> childObjects = new ArrayList<>();
-
-		for(BeanDefinition propertyDefinition : propertyDefinitions) {
-			Type genericType;
-			if(propertyDefinition.hasField()) {
-				genericType = propertyDefinition.getField().getAnnotated().getGenericType();
-			} else if(propertyDefinition.hasGetter()) {
-				genericType = propertyDefinition.getGetter().getAnnotated().getGenericReturnType();
-			} else if(propertyDefinition.hasSetter()
-				&& propertyDefinition.getSetter().getAnnotated().getGenericParameterTypes().length == 1) {
-				genericType = propertyDefinition.getSetter().getAnnotated().getGenericParameterTypes()[0];
-			} else {
-				continue;
-			}
-			childObjects.add(new ChildObject(propertyDefinition,
-				new DataObject(explored.getContextualType(genericType), context, explored.getFlow())));
-		}
-		return childObjects;
 	}
 
 	/**
@@ -318,43 +293,4 @@ public class TagLibrary {
 		return javadocMap;
 	}
 
-	private List<BeanDefinition> getPropertyDefinitions(ObjectMapper mapper, DataObject dataObject) {
-		Class<?> clazz = dataObject.getJavaClass();
-		if(dataObject.getFlow() == Flow.INPUT) {
-			DeserializationConfig deserializationConfig = mapper.getDeserializationConfig();
-			JavaType type = deserializationConfig.constructType(clazz);
-			BeanDescription deserializationDescription = deserializationConfig.introspect(type);
-			return deserializationDescription.findProperties().stream()
-				.map(p -> new BeanDefinition(p, null, dataObject.getFlow()))
-				.filter(BeanDefinition::couldDeserialize)
-				.collect(Collectors.toList());
-		} else if(dataObject.getFlow() == Flow.OUTPUT) {
-			SerializationConfig serializationConfig = mapper.getSerializationConfig();
-			JavaType type = serializationConfig.constructType(clazz);
-			BeanDescription serializationDescription = serializationConfig.introspect(type);
-			return serializationDescription.findProperties().stream().map(p -> new BeanDefinition(p, null, dataObject.getFlow()))
-				.filter(BeanDefinition::couldSerialize)
-				.collect(Collectors.toList());
-		}
-
-		// Mix input and output data
-		SerializationConfig serializationConfig = mapper.getSerializationConfig();
-		JavaType type = serializationConfig.constructType(clazz);
-		BeanDescription serializationDescription = serializationConfig.introspect(type);
-
-		DeserializationConfig deserializationConfig = mapper.getDeserializationConfig();
-		BeanDescription deserializationDescription = deserializationConfig.introspect(type);
-
-		Map<String, BeanPropertyDefinition> deserialMap = deserializationDescription.findProperties().stream()
-			.collect(Collectors.toMap(BeanPropertyDefinition::getName, p -> p, (a, b) -> a, LinkedHashMap::new));
-
-		List<BeanDefinition> list = new ArrayList<>();
-		for(BeanPropertyDefinition beanDef : serializationDescription.findProperties()) {
-			list.add(new BeanDefinition(beanDef, deserialMap.remove(beanDef.getName()), Flow.INPUT_OUTPUT));
-		}
-		for(BeanPropertyDefinition beanDef : deserialMap.values()) {
-			list.add(new BeanDefinition(beanDef, null, Flow.INPUT_OUTPUT));
-		}
-		return list;
-	}
 }

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/BeanDefinitionUtils.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/BeanDefinitionUtils.java
@@ -1,0 +1,82 @@
+package io.github.kbuntrock.configuration.library.reader;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import io.github.kbuntrock.context.ApiContext;
+import io.github.kbuntrock.model.DataObject;
+import io.github.kbuntrock.model.Flow;
+import io.github.kbuntrock.reflection.BeanDefinition;
+import io.github.kbuntrock.yaml.model.ChildObject;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BeanDefinitionUtils {
+
+	private static List<BeanDefinition> getPropertyDefinitions(ObjectMapper mapper, DataObject dataObject) {
+		Class<?> clazz = dataObject.getJavaClass();
+		if(dataObject.getFlow() == Flow.INPUT) {
+			DeserializationConfig deserializationConfig = mapper.getDeserializationConfig();
+			JavaType type = deserializationConfig.constructType(clazz);
+			BeanDescription deserializationDescription = deserializationConfig.introspect(type);
+			return deserializationDescription.findProperties().stream()
+				.map(p -> new BeanDefinition(p, null, dataObject.getFlow()))
+				.filter(BeanDefinition::couldDeserialize)
+				.collect(Collectors.toList());
+		} else if(dataObject.getFlow() == Flow.OUTPUT) {
+			SerializationConfig serializationConfig = mapper.getSerializationConfig();
+			JavaType type = serializationConfig.constructType(clazz);
+			BeanDescription serializationDescription = serializationConfig.introspect(type);
+			return serializationDescription.findProperties().stream().map(p -> new BeanDefinition(p, null, dataObject.getFlow()))
+				.filter(BeanDefinition::couldSerialize)
+				.collect(Collectors.toList());
+		}
+
+		// Mix input and output data
+		SerializationConfig serializationConfig = mapper.getSerializationConfig();
+		JavaType type = serializationConfig.constructType(clazz);
+		BeanDescription serializationDescription = serializationConfig.introspect(type);
+
+		DeserializationConfig deserializationConfig = mapper.getDeserializationConfig();
+		BeanDescription deserializationDescription = deserializationConfig.introspect(type);
+
+		Map<String, BeanPropertyDefinition> deserialMap = deserializationDescription.findProperties().stream()
+			.collect(Collectors.toMap(BeanPropertyDefinition::getName, p -> p, (a, b) -> a, LinkedHashMap::new));
+
+		List<BeanDefinition> list = new ArrayList<>();
+		for(BeanPropertyDefinition beanDef : serializationDescription.findProperties()) {
+			list.add(new BeanDefinition(beanDef, deserialMap.remove(beanDef.getName()), Flow.INPUT_OUTPUT));
+		}
+		for(BeanPropertyDefinition beanDef : deserialMap.values()) {
+			list.add(new BeanDefinition(beanDef, null, Flow.INPUT_OUTPUT));
+		}
+		return list;
+	}
+
+	public static List<ChildObject> getPropertyObjectsToDocument(DataObject explored, final ApiContext context) {
+		List<BeanDefinition> propertyDefinitions = getPropertyDefinitions(context.getSchemaObjectMapper(),
+			explored);
+		List<ChildObject> childObjects = new ArrayList<>();
+
+		for(BeanDefinition propertyDefinition : propertyDefinitions) {
+			Type genericType;
+			if(propertyDefinition.hasField()) {
+				genericType = propertyDefinition.getField().getAnnotated().getGenericType();
+			} else if(propertyDefinition.hasGetter()) {
+				genericType = propertyDefinition.getGetter().getAnnotated().getGenericReturnType();
+			} else if(propertyDefinition.hasSetter()
+				&& propertyDefinition.getSetter().getAnnotated().getGenericParameterTypes().length == 1) {
+				genericType = propertyDefinition.getSetter().getAnnotated().getGenericParameterTypes()[0];
+			} else {
+				continue;
+			}
+			childObjects.add(new ChildObject(propertyDefinition,
+				new DataObject(explored.getContextualType(genericType), context, explored.getFlow())));
+		}
+		return childObjects;
+	}
+}

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
@@ -1,23 +1,25 @@
 package io.github.kbuntrock.configuration.library.reader;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.github.kbuntrock.JavaClassAnalyser;
 import io.github.kbuntrock.MojoRuntimeException;
 import io.github.kbuntrock.configuration.ApiConfiguration;
 import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.model.*;
-import io.github.kbuntrock.reflection.ReflectionsUtils;
 import io.github.kbuntrock.reflection.annotation.MergedAnnotation;
 import io.github.kbuntrock.reflection.annotation.MergedAnnotations;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
 import io.github.kbuntrock.utils.ParameterLocation;
+import io.github.kbuntrock.yaml.model.ChildObject;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.maven.plugin.MojoFailureException;
 
 import java.io.File;
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
@@ -27,7 +29,6 @@ import java.time.ZoneId;
 import java.time.temporal.Temporal;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class SpringMvcReader extends AbstractLibraryReader {
 
@@ -166,6 +167,8 @@ public class SpringMvcReader extends AbstractLibraryReader {
 
 		readRequestMappingHeaders(endpointAnnotations, parameters);
 
+		Set<String> modelAttributeBanned = new HashSet<>();
+
 		for(final Method method : overriddenMethods) {
 			for(final Parameter parameter : method.getParameters()) {
 
@@ -180,6 +183,14 @@ public class SpringMvcReader extends AbstractLibraryReader {
 					(name) -> unwrapParameterObject(
 						new ParameterObject(name, genericityResolver.resolve(clazz, parameter.getParameterizedType()),
 							context)));
+
+				final MergedAnnotation modelAttribute = mergedAnnotations
+					.get("org.springframework.web.bind.annotation.ModelAttribute");
+				if(modelAttribute.isPresent() && !modelAttribute.getBoolean("binding")) {
+					// Binding is explicitly disabled for this annotated parameter
+					modelAttributeBanned.add(parameter.getName());
+					continue;
+				}
 
 				boolean annotationFound = false;
 				// Detect if is a header variable
@@ -283,15 +294,21 @@ public class SpringMvcReader extends AbstractLibraryReader {
 			}
 		}
 
-		// Last case, some Dto fields can be bound to QueryParams : http://dolszewski.com/spring/how-to-bind-requestparam-to-object/
-		// Since this functionality is not well documented, it can be for now a subset of the complete functionality
-		final Map<String, ParameterObject> unnestedParams = new LinkedHashMap<>(parameters);
-		parameters.values().stream().filter(x -> x.getLocation() == null && parameterObjectBindableToQueryParams(x))
-			.forEach(paramObj -> {
-				bindDtoToQueryParams(unnestedParams, paramObj);
-			});
-
-		return unnestedParams.values().stream().filter(x -> x.getLocation() != null).collect(Collectors.toList());
+		// Handle in a basic way (query param binding) explicit or implicit @ModelAttribute
+		// See https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-methods/modelattrib-method-args.html
+		final Map<String, ParameterObject> unnestedParams = new LinkedHashMap<>();
+		for(ParameterObject paramObj : parameters.values()) {
+			if(paramObj.getLocation() == null) {
+				List<ChildObject> bindableToQueryParams = parameterObjectBindableToQueryParams(paramObj);
+				for(ChildObject childProperty : bindableToQueryParams) {
+					ParameterObject queryParam = bindDtoToQueryParams(paramObj, childProperty);
+					unnestedParams.putIfAbsent(queryParam.getName(), queryParam);
+				}
+			} else {
+				unnestedParams.putIfAbsent(paramObj.getName(), paramObj);
+			}
+		}
+		return new ArrayList<>(unnestedParams.values());
 	}
 
 	/**
@@ -378,44 +395,28 @@ public class SpringMvcReader extends AbstractLibraryReader {
 		}
 	}
 
-	private boolean parameterObjectBindableToQueryParams(final ParameterObject paramObj) {
-		final List<Field> fields = ReflectionsUtils.getAllNonStaticFields(new ArrayList<>(), paramObj.getJavaClass());
-		for(final Field field : fields) {
-			if(field.isAnnotationPresent(JsonIgnore.class)) {
-				// Field is tagged ignore. No need to document it.
-				continue;
-			}
-			if(!(isSimpleProperty(field.getType()) ||
-				Collection.class.isAssignableFrom(field.getType()) ||
-				field.getType().isArray())) {
-				return false;
+	private List<ChildObject> parameterObjectBindableToQueryParams(final ParameterObject paramObj) {
+		List<ChildObject> bindables = new ArrayList<>();
+		List<ChildObject> childProperties = BeanDefinitionUtils.getPropertyObjectsToDocument(paramObj, context);
+		for(ChildObject childProperty : childProperties) {
+			if(isSimpleProperty(childProperty.getDataObject().getJavaClass()) ||
+				Collection.class.isAssignableFrom(childProperty.getDataObject().getJavaClass()) ||
+				childProperty.getDataObject().getJavaClass().isArray()) {
+				bindables.add(childProperty);
 			}
 		}
-		return true;
+		return bindables;
 	}
 
-	private void bindDtoToQueryParams(final Map<String, ParameterObject> parameters, final ParameterObject paramObj) {
+	private ParameterObject bindDtoToQueryParams(final ParameterObject paramObj, final ChildObject childObject) {
 
-		final List<Field> fields = ReflectionsUtils.getAllNonStaticFields(new ArrayList<>(), paramObj.getJavaClass());
-		for(final Field field : fields) {
-			final ParameterObject fieldObj = parameters.computeIfAbsent(field.getName(),
-				(name) -> unwrapParameterObject(
-					new ParameterObject(name, paramObj.getContextualType(field.getGenericType()), context)));
-			fieldObj.setLocation(ParameterLocation.QUERY);
-			fieldObj.setJavadocFieldClassName(paramObj.getJavaClass().getCanonicalName());
-			// Class "requirement" has precedence on any annotation (we can't force an optional to be required ...)
-			if(fieldObj.getClassRequired() != null) {
-				fieldObj.setRequired(paramObj.getClassRequired());
-			} else {
-				if(context.getNullableConfiguration().hasNonNullAnnotation(Arrays.asList(field.getAnnotations()))) {
-					fieldObj.setRequired(true);
-				} else if(context.getNullableConfiguration().hasNullableAnnotation(Arrays.asList(field.getAnnotations()))) {
-					fieldObj.setRequired(false);
-				} else {
-					fieldObj.setRequired(context.getNullableConfiguration().isDefaultNonNullableFields());
-				}
-			}
+		final ParameterObject fieldObj = new ParameterObject(childObject.getName(), childObject.getDataObject());
+		fieldObj.setLocation(ParameterLocation.QUERY);
+		fieldObj.setJavadocFieldClassName(paramObj.getJavaClass().getCanonicalName());
+		if(childObject.getDataObject().getClassRequired() != null) {
+			fieldObj.setRequired(childObject.getDataObject().getClassRequired());
 		}
+		return fieldObj;
 	}
 
 	@Override

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.github.kbuntrock.JavaClassAnalyser;
 import io.github.kbuntrock.TagLibrary;
 import io.github.kbuntrock.configuration.ApiConfiguration;
+import io.github.kbuntrock.configuration.library.reader.BeanDefinitionUtils;
 import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.javadoc.ClassDocumentation;
 import io.github.kbuntrock.javadoc.ClassDocumentation.EnhancementType;
@@ -273,7 +274,7 @@ public class Schema {
 				}
 			}
 		} else {
-			List<ChildObject> childProperties = tagLibrary.getPropertyObjectsToDocument(dataObject);
+			List<ChildObject> childProperties = BeanDefinitionUtils.getPropertyObjectsToDocument(dataObject, context);
 			for(ChildObject child : childProperties) {
 				final DataObject propertyObject = tagLibrary.getOpenApiTypeResolver().unwrapDataObject(
 					child.getDataObject(),

--- a/openapi-maven-plugin/src/main/resources/non-documentable-parameters.yml
+++ b/openapi-maven-plugin/src/main/resources/non-documentable-parameters.yml
@@ -23,4 +23,3 @@ spring:
 spring-annotations:
   - org.springframework.web.bind.annotation.RequestAttribute
   - org.springframework.web.bind.annotation.SessionAttribute
-  - org.springframework.web.bind.annotation.ModelAttribute

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
@@ -2,11 +2,7 @@ package io.github.kbuntrock;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
-import io.github.kbuntrock.configuration.ApiConfiguration;
-import io.github.kbuntrock.configuration.CommonApiConfiguration;
-import io.github.kbuntrock.configuration.JavadocConfiguration;
-import io.github.kbuntrock.configuration.OperationIdHelper;
-import io.github.kbuntrock.configuration.Substitution;
+import io.github.kbuntrock.configuration.*;
 import io.github.kbuntrock.configuration.library.TagAnnotation;
 import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.context.ProjectContext;
@@ -17,38 +13,11 @@ import io.github.kbuntrock.resources.endpoint.annotation.AnnotatedController;
 import io.github.kbuntrock.resources.endpoint.collection.CollectionController;
 import io.github.kbuntrock.resources.endpoint.collision.FirstEndpoint;
 import io.github.kbuntrock.resources.endpoint.collision.SecondEndpoint;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration1Controller;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration2Controller;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration3Controller;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration4Controller;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration5Controller;
-import io.github.kbuntrock.resources.endpoint.enumeration.TestEnumeration6Controller;
+import io.github.kbuntrock.resources.endpoint.enumeration.*;
 import io.github.kbuntrock.resources.endpoint.error.SameOperationController;
 import io.github.kbuntrock.resources.endpoint.file.FileUploadController;
 import io.github.kbuntrock.resources.endpoint.file.StreamResponseController;
-import io.github.kbuntrock.resources.endpoint.generic.ExtendsGenericObjectMap;
-import io.github.kbuntrock.resources.endpoint.generic.ExtendsList;
-import io.github.kbuntrock.resources.endpoint.generic.ExtendsListV2;
-import io.github.kbuntrock.resources.endpoint.generic.ExtendsMap;
-import io.github.kbuntrock.resources.endpoint.generic.GenericDataController;
-import io.github.kbuntrock.resources.endpoint.generic.GenericMappingObject;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestEight;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestEleven;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestFive;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestFour;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestNine;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestOne;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestSeven;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestSix;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestTen;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestThree;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestTwelve;
-import io.github.kbuntrock.resources.endpoint.generic.GenericityTestTwo;
-import io.github.kbuntrock.resources.endpoint.generic.Issue144;
-import io.github.kbuntrock.resources.endpoint.generic.Issue144ByInterface;
-import io.github.kbuntrock.resources.endpoint.generic.Issue89;
-import io.github.kbuntrock.resources.endpoint.generic.Issue95;
-import io.github.kbuntrock.resources.endpoint.generic.MappingObject;
+import io.github.kbuntrock.resources.endpoint.generic.*;
 import io.github.kbuntrock.resources.endpoint.header.MultipartFileWithHeaderController;
 import io.github.kbuntrock.resources.endpoint.ignore.JsonIgnoreController;
 import io.github.kbuntrock.resources.endpoint.interfacedto.InterfaceController;
@@ -68,16 +37,8 @@ import io.github.kbuntrock.resources.endpoint.operation.MultipleProducedContentT
 import io.github.kbuntrock.resources.endpoint.operation.MultipleProducedContentTypesParameterIncoherence;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementOneController;
 import io.github.kbuntrock.resources.endpoint.path.SpringPathEnhancementTwoController;
-import io.github.kbuntrock.resources.endpoint.queryparam.EmptyValueParameterController;
-import io.github.kbuntrock.resources.endpoint.queryparam.QueryParamDtoBindingController;
-import io.github.kbuntrock.resources.endpoint.queryparam.QueryParamFlatMixNestedDtoBindingController;
-import io.github.kbuntrock.resources.endpoint.queryparam.QueryParamInMappingController;
-import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveDtoController;
-import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveInterfaceDtoController;
-import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveInterfaceListDtoInParameterController;
-import io.github.kbuntrock.resources.endpoint.recursive.GenericRecursiveListDtoController;
-import io.github.kbuntrock.resources.endpoint.recursive.RecursiveDtoController;
-import io.github.kbuntrock.resources.endpoint.recursive.RecursiveDtoInParameterController;
+import io.github.kbuntrock.resources.endpoint.queryparam.*;
+import io.github.kbuntrock.resources.endpoint.recursive.*;
 import io.github.kbuntrock.resources.endpoint.spring.OptionalController;
 import io.github.kbuntrock.resources.endpoint.spring.ResponseEntityController;
 import io.github.kbuntrock.resources.endpoint.spring.ResponseEntityUnparametrizedController;
@@ -100,12 +61,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 public class SpringClassAnalyserTest extends AbstractTest {
 
@@ -825,6 +781,18 @@ public class SpringClassAnalyserTest extends AbstractTest {
 	public void query_param_dto_binding() throws MojoFailureException, IOException, MojoExecutionException {
 
 		final DocumentationMojo mojo = createBasicMojo(QueryParamDtoBindingController.class.getCanonicalName());
+		final JavadocConfiguration javadocConfig = new JavadocConfiguration();
+		javadocConfig.setScanLocations(Arrays.asList("src/test/java/io/github/kbuntrock/resources/endpoint/queryparam",
+			"src/test/java/io/github/kbuntrock/resources/dto"));
+		mojo.setJavadocConfiguration(javadocConfig);
+
+		checkGenerationResult(mojo.documentProject());
+	}
+
+	@Test
+	public void model_attribute() throws MojoFailureException, IOException, MojoExecutionException {
+
+		final DocumentationMojo mojo = createBasicMojo(ModelAttributeController.class.getCanonicalName());
 		final JavadocConfiguration javadocConfig = new JavadocConfiguration();
 		javadocConfig.setScanLocations(Arrays.asList("src/test/java/io/github/kbuntrock/resources/endpoint/queryparam",
 			"src/test/java/io/github/kbuntrock/resources/dto"));

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/ModelAttributeController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/ModelAttributeController.java
@@ -1,0 +1,14 @@
+package io.github.kbuntrock.resources.endpoint.queryparam;
+
+import io.github.kbuntrock.resources.dto.TimeDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("api")
+public interface ModelAttributeController {
+
+	@GetMapping("is-time-valid")
+	boolean isTimeValid(@ModelAttribute TimeDto time);
+
+}

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.model_attribute.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.model_attribute.approved.txt
@@ -1,0 +1,44 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: ModelAttributeController
+paths:
+  /api/is-time-valid:
+    get:
+      tags:
+        - ModelAttributeController
+      operationId: isTimeValid
+      parameters:
+        - name: instant
+          description: The instant field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: date
+          description: The date field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: dateTime
+          description: The date time field
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+      responses:
+        200:
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: boolean

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_flat_mix_nested_dto_binding.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_flat_mix_nested_dto_binding.approved.txt
@@ -19,12 +19,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-            format: int32
         - name: instant
           description: The instant field
           in: query
@@ -46,6 +40,12 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
       responses:
         200:
           description: successful operation


### PR DESCRIPTION
Handle @ModelAttribute as a query param binding on all "simple objects" de-serialisable attributes.