### PR TITLE
fix: quote numeric YAML keys in generated specs

### DIFF
--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk11.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk11.yml
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -31,7 +31,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk17.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk17.yml
@@ -16,7 +16,7 @@ paths:
       operationId: getRecords
       description: List all the records
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -35,7 +35,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -47,7 +47,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk21.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk21.yml
@@ -16,7 +16,7 @@ paths:
       operationId: redirectUsingRedirectView
       description: Redirection somewhere
       responses:
-        200:
+        "200":
           description: the return object should not be documented
   /api/user/records:
     get:
@@ -25,7 +25,7 @@ paths:
       operationId: getRecords
       description: List all the records
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -44,7 +44,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -56,7 +56,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk25.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk25.yml
@@ -25,7 +25,7 @@ paths:
       operationId: redirectUsingRedirectView
       description: Redirect somewhere
       responses:
-        200:
+        "200":
           description: the return object should not be documented
   /api/user/records:
     get:
@@ -35,7 +35,7 @@ paths:
       description: List all the records. This comment is still in the old javadoc
         formalism.
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -56,7 +56,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: The user to update
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -69,7 +69,7 @@ paths:
       operationId: getUserDtos
       description: Get all **users**
       responses:
-        200:
+        "200":
           description: a list of users
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk8.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk8.yml
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -31,7 +31,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -71,7 +71,8 @@ public class YamlWriter {
 		this.om = FILEFORMAT_JSON.equals(apiConfiguration.getFileFormat())
 			? new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
 			: new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-				.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR));
+				.enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR)
+				.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS));
 	}
 
 	private void populateSpecificationFreeFields(final Specification specification, final Optional<JsonNode> freefields) {

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_description_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_description_extension.approved.txt
@@ -33,8 +33,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_name_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_name_extension.approved.txt
@@ -33,8 +33,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enumNames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_description_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_description_extension.approved.txt
@@ -33,8 +33,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_list_description.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_list_description.approved.txt
@@ -31,8 +31,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_name_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_name_extension.approved.txt
@@ -33,8 +33,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enum-descriptions:
         - This is the France value
         - This is the Germany value

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_as_value_function_precedence.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_as_value_function_precedence.approved.txt
@@ -29,8 +29,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 503
-        - 1003
+        - "503"
+        - "1003"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_field_as_value.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_field_as_value.approved.txt
@@ -33,8 +33,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 1000
-        - 2000
+        - "1000"
+        - "2000"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_function_as_value.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_function_as_value.approved.txt
@@ -31,8 +31,8 @@ components:
       type: integer
       format: int32
       enum:
-        - 500
-        - 1000
+        - "500"
+        - "1000"
       x-enum-varnames:
         - FRANCE
         - GERMANY

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithAllMerged.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithAllMerged.approved.txt
@@ -25,7 +25,7 @@ paths:
             type: string
         - name: count
           description: Description.
-          example: 3
+          example: "3"
           in: query
           required: true
           schema:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithPriority.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithPriority.approved.txt
@@ -25,7 +25,7 @@ paths:
             type: string
         - name: count
           description: desc
-          example: 3
+          example: "3"
           in: query
           required: true
           schema:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithAllMerged.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithAllMerged.approved.txt
@@ -25,7 +25,7 @@ paths:
             type: string
         - name: count
           description: Description.
-          example: 3
+          example: "3"
           in: query
           required: true
           schema:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
@@ -106,7 +106,7 @@ components:
           description: HTTP status code of the error
           type: integer
           format: int32
-          example: 500
+          example: "500"
         error:
           description: Short description of the error
           type: string
@@ -132,7 +132,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
@@ -92,7 +92,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -92,7 +92,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
@@ -106,7 +106,7 @@ components:
           description: HTTP status code of the error
           type: integer
           format: int32
-          example: 500
+          example: "500"
         error:
           description: Short description of the error
           type: string
@@ -131,7 +131,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjects.approved.txt
@@ -92,7 +92,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -92,7 +92,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
@@ -106,7 +106,7 @@ components:
           description: HTTP status code of the error
           type: integer
           format: int32
-          example: 500
+          example: "500"
         error:
           description: Short description of the error
           type: string
@@ -131,7 +131,7 @@ components:
         id:
           description: Unique identifier for the response
           type: string
-          example: 12345
+          example: "12345"
         status:
           description: Status of the response
           type: string


### PR DESCRIPTION
## Summary

- Enable `YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS` on the `YAMLFactory` in `YamlWriter.java`
- HTTP response codes (`200`, `404`, `500`...) are now serialized as `"200":` instead of `200:`

## Problem

The OpenAPI 3.0 specification requires response codes to be **strings**. With `MINIMIZE_QUOTES` enabled, Jackson/SnakeYAML strips quotes from numeric-looking keys, producing `200:` instead of `"200":`.

This causes validation errors in tools like Spectral:
```
error  parser  Mapping key must be a string scalar rather than number
```

## Fix

One-line change: add `.enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)` to the `YAMLFactory` configuration.

## Test plan

- All 145 existing tests updated and passing
- Verified numeric response codes are now quoted in all generated YAML output