### PR TITLE
fix: wrap $ref in allOf when sibling properties exist (OpenAPI 3.0)

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Schema.java
@@ -496,6 +496,18 @@ public class Schema {
 
 		final Map<String, Object> map = new LinkedHashMap<>();
 
+		// In OpenAPI 3.0, a $ref must not have sibling properties. When a reference
+		// coexists with a description (or other fields), wrap the $ref inside an allOf
+		// so that the description stays at the current level while the reference is
+		// isolated inside the allOf entry.
+		if(StringUtils.isNotBlank(reference) && description != null) {
+			map.put("description", description);
+			final Map<String, Object> refMap = new LinkedHashMap<>();
+			refMap.put(OpenApiConstants.OBJECT_REFERENCE_DECLARATION, reference);
+			map.put("allOf", Collections.singletonList(refMap));
+			return map;
+		}
+
 		// Elsewhere, resolved type only describe vaguely the type (object or array), and we write all the infos
 		if(description != null) {
 			map.put("description", description);

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_1.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_1.approved.txt
@@ -84,7 +84,8 @@ components:
         account:
           description: "account is serialization only: emitted in JSON, ignored on\
             \ input"
-          $ref: '#/components/schemas/AccountJacksonDto'
+          allOf:
+            - $ref: '#/components/schemas/AccountJacksonDto'
         customerEmail:
           description: customerEmail is a regular field (read/write)
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_2.approved.txt
@@ -112,7 +112,8 @@ components:
         account:
           description: "account is serialization only: emitted in JSON, ignored on\
             \ input"
-          $ref: '#/components/schemas/AccountJacksonDto'
+          allOf:
+            - $ref: '#/components/schemas/AccountJacksonDto'
           readOnly: true
         customerEmail:
           description: customerEmail is a regular field (read/write)
@@ -128,7 +129,8 @@ components:
       properties:
         account:
           description: Account of the resume (write only)
-          $ref: '#/components/schemas/AccountJacksonDto'
+          allOf:
+            - $ref: '#/components/schemas/AccountJacksonDto'
         description:
           description: Description of the resume
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_output.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_output.approved.txt
@@ -53,7 +53,8 @@ components:
         account:
           description: "account is serialization only: emitted in JSON, ignored on\
             \ input"
-          $ref: '#/components/schemas/AccountJacksonDto'
+          allOf:
+            - $ref: '#/components/schemas/AccountJacksonDto'
         customerEmail:
           description: customerEmail is a regular field (read/write)
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_dto.approved.txt
@@ -28,7 +28,8 @@ paths:
                     type: string
                   wrapped:
                     description: The generic wrapped object
-                    $ref: '#/components/schemas/AccountDto'
+                    allOf:
+                      - $ref: '#/components/schemas/AccountDto'
                   child:
                     description: The recursive property
                     type: object
@@ -38,10 +39,12 @@ paths:
                         type: string
                       wrapped:
                         description: The generic wrapped object
-                        $ref: '#/components/schemas/AccountDto'
+                        allOf:
+                          - $ref: '#/components/schemas/AccountDto'
                       child:
                         description: The recursive property
-                        $ref: '#/components/schemas/GenericRecursiveDto_AccountDto'
+                        allOf:
+                          - $ref: '#/components/schemas/GenericRecursiveDto_AccountDto'
 components:
   schemas:
     AccountDto:
@@ -115,7 +118,8 @@ components:
           type: string
         wrapped:
           description: The generic wrapped object
-          $ref: '#/components/schemas/AccountDto'
+          allOf:
+            - $ref: '#/components/schemas/AccountDto'
         child:
           description: The recursive property
           type: object
@@ -125,7 +129,9 @@ components:
               type: string
             wrapped:
               description: The generic wrapped object
-              $ref: '#/components/schemas/AccountDto'
+              allOf:
+                - $ref: '#/components/schemas/AccountDto'
             child:
               description: The recursive property
-              $ref: '#/components/schemas/GenericRecursiveDto_AccountDto'
+              allOf:
+                - $ref: '#/components/schemas/GenericRecursiveDto_AccountDto'

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.interface_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.interface_dto.approved.txt
@@ -25,10 +25,12 @@ paths:
                 properties:
                   account:
                     description: Comment on getAccount
-                    $ref: '#/components/schemas/AccountDto'
+                    allOf:
+                      - $ref: '#/components/schemas/AccountDto'
                   generic:
                     description: Comment on getGeneric
-                    $ref: '#/components/schemas/TimeDto'
+                    allOf:
+                      - $ref: '#/components/schemas/TimeDto'
                   genericList:
                     description: Comment on getGenericList
                     type: array

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_89.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_89.approved.txt
@@ -38,10 +38,12 @@ components:
       properties:
         a:
           description: the a attribute
-          $ref: '#/components/schemas/Foo'
+          allOf:
+            - $ref: '#/components/schemas/Foo'
         b:
           description: the b attribute
-          $ref: '#/components/schemas/Boo'
+          allOf:
+            - $ref: '#/components/schemas/Boo'
         foo:
           description: the foo integer
           type: integer
@@ -58,10 +60,12 @@ components:
       properties:
         a:
           description: the a attribute
-          $ref: '#/components/schemas/Foo'
+          allOf:
+            - $ref: '#/components/schemas/Foo'
         b:
           description: the b attribute
-          $ref: '#/components/schemas/Boo'
+          allOf:
+            - $ref: '#/components/schemas/Boo'
         foo:
           description: the foo integer
           type: integer
@@ -75,10 +79,12 @@ components:
       properties:
         a:
           description: the a attribute
-          $ref: '#/components/schemas/Foo'
+          allOf:
+            - $ref: '#/components/schemas/Foo'
         b:
           description: the b attribute
-          $ref: '#/components/schemas/Boo'
+          allOf:
+            - $ref: '#/components/schemas/Boo'
         foo:
           description: the foo integer
           type: integer
@@ -89,10 +95,12 @@ components:
       properties:
         a:
           description: get the A attribute
-          $ref: '#/components/schemas/IFoo'
+          allOf:
+            - $ref: '#/components/schemas/IFoo'
         b:
           description: Get the B attribute
-          $ref: '#/components/schemas/IBoo'
+          allOf:
+            - $ref: '#/components/schemas/IBoo'
         bar:
           description: The bar string
           type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multipart_formdata.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multipart_formdata.approved.txt
@@ -27,7 +27,8 @@ paths:
               properties:
                 metadata:
                   description: Some metadata about this file
-                  $ref: '#/components/schemas/MetadataDto'
+                  allOf:
+                    - $ref: '#/components/schemas/MetadataDto'
                 goal:
                   description: The upload goal
                   type: string
@@ -62,7 +63,8 @@ paths:
               properties:
                 metadata:
                   description: Some metadata about this file
-                  $ref: '#/components/schemas/MetadataDto'
+                  allOf:
+                    - $ref: '#/components/schemas/MetadataDto'
                 goal:
                   description: The upload goal
                   type: string
@@ -101,7 +103,8 @@ paths:
               properties:
                 metadata:
                   description: Some metadata about this file
-                  $ref: '#/components/schemas/MetadataDto'
+                  allOf:
+                    - $ref: '#/components/schemas/MetadataDto'
                 goal:
                   description: The upload goal
                   type: string

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
@@ -59,7 +59,8 @@ paths:
             '*/*':
               schema:
                 description: The success entity
-                $ref: '#/components/schemas/SuccessEntity'
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEntity'
         "404":
           description: Not Found
           content:
@@ -125,7 +126,8 @@ components:
           example: Additional information about the error
         cause:
           description: "The cause of the error, if any"
-          $ref: '#/components/schemas/ErrorEntityWithAnnotations'
+          allOf:
+            - $ref: '#/components/schemas/ErrorEntityWithAnnotations'
     ResponseEntityWithAnnotations:
       type: object
       properties:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
@@ -59,7 +59,8 @@ paths:
             '*/*':
               schema:
                 description: The success entity
-                $ref: '#/components/schemas/SuccessEntity'
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEntity'
         "404":
           description: Not Found
           content:
@@ -124,7 +125,8 @@ components:
           example: Additional information about the error
         cause:
           description: "The cause of the error, if any"
-          $ref: '#/components/schemas/ErrorEntityWithAnnotations'
+          allOf:
+            - $ref: '#/components/schemas/ErrorEntityWithAnnotations'
     ResponseEntityWithAnnotations:
       type: object
       properties:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
@@ -59,7 +59,8 @@ paths:
             '*/*':
               schema:
                 description: The success entity
-                $ref: '#/components/schemas/SuccessEntity'
+                allOf:
+                  - $ref: '#/components/schemas/SuccessEntity'
         "404":
           description: Not Found
           content:
@@ -124,7 +125,8 @@ components:
           example: Additional information about the error
         cause:
           description: "The cause of the error, if any"
-          $ref: '#/components/schemas/ErrorEntityWithAnnotations'
+          allOf:
+            - $ref: '#/components/schemas/ErrorEntityWithAnnotations'
     ResponseEntityWithAnnotations:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- When a schema property has both a `$ref` and a `description`, wrap the `$ref` inside an `allOf` array
- Other sibling properties (`readOnly`, `writeOnly`, etc.) remain at the property level as intended

## Problem

In OpenAPI 3.0, a `$ref` must not have sibling properties — any adjacent fields are ignored by compliant parsers.

This is specified in the [OpenAPI 3.0.3 specification, section 4.8.23 — Reference Object](https://spec.openapis.org/oas/v3.0.3#reference-object):

> *"This object cannot be extended with additional properties and any properties added SHALL be ignored."*

The plugin currently outputs:

```yaml
property:
  description: Some text
  $ref: '#/components/schemas/Foo'
```

This triggers Spectral `no-$ref-siblings` warnings and can cause incorrect behavior in code generators that strictly follow the 3.0 spec (the `description` is silently ignored).

**Note:** This restriction was lifted in OpenAPI 3.1 (based on JSON Schema 2020-12), where `$ref` can have siblings. But as long as the plugin generates 3.0.x specs, the `allOf` wrapping is the correct approach.

## Fix

In `Schema.getJsonObject()`, when both `reference` and `description` are present, return early with an `allOf`-wrapped structure:

```yaml
property:
  description: Some text
  allOf:
    - $ref: '#/components/schemas/Foo'
```

The `Property` subclass continues to add its own fields (`readOnly`, `writeOnly`, `minLength`, `maxLength`, `example`) to the returned map, which is valid as siblings of `allOf` in OpenAPI 3.0.

## Test plan

- All 145 existing tests updated and passing
- Verified `$ref` is properly wrapped in `allOf` when description is present
- Verified `readOnly`/`writeOnly` remain at the correct level