### PR TITLE
fix: quote numeric YAML keys in generated OpenAPI specs

### DIFF
--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk11.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk11.yml
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -31,7 +31,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk17.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk17.yml
@@ -16,7 +16,7 @@ paths:
       operationId: getRecords
       description: List all the records
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -35,7 +35,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -47,7 +47,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk21.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk21.yml
@@ -16,7 +16,7 @@ paths:
       operationId: redirectUsingRedirectView
       description: Redirection somewhere
       responses:
-        200:
+        "200":
           description: the return object should not be documented
   /api/user/records:
     get:
@@ -25,7 +25,7 @@ paths:
       operationId: getRecords
       description: List all the records
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -44,7 +44,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -56,7 +56,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk25.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk25.yml
@@ -25,7 +25,7 @@ paths:
       operationId: redirectUsingRedirectView
       description: Redirect somewhere
       responses:
-        200:
+        "200":
           description: the return object should not be documented
   /api/user/records:
     get:
@@ -35,7 +35,7 @@ paths:
       description: List all the records. This comment is still in the old javadoc
         formalism.
       responses:
-        200:
+        "200":
           description: all the available records
           content:
             application/json:
@@ -56,7 +56,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: The user to update
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -69,7 +69,7 @@ paths:
       operationId: getUserDtos
       description: Get all **users**
       responses:
-        200:
+        "200":
           description: a list of users
           content:
             application/json:

--- a/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk8.yml
+++ b/integration-tests/src/test/resources/it/BasicIT/nominal_test_case-jdk8.yml
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -31,7 +31,7 @@ paths:
         - UserController
       operationId: getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -454,7 +454,7 @@ public class YamlWriter {
 				for(final OperationResponse operationResponse : endpoint.getOperationAnnotationInfo().getResponses()) {
 					// Check if response code is already documented, if so, we merge the attributes
 					Response annotatedResponse = null;
-					Object additionalResponseObject = operation.getResponses().get(operationResponse.getCode());
+					Object additionalResponseObject = operation.getResponses().get(String.valueOf(operationResponse.getCode()));
 					if(additionalResponseObject != null && additionalResponseObject instanceof Response) {
 						annotatedResponse = (Response) additionalResponseObject;
 					} else {

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Response.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/model/Response.java
@@ -28,13 +28,12 @@ public class Response {
 		return code;
 	}
 
-	public void setCode(Object code, String defaultSuccessfulOperationDescription) {
-		this.code = code;
-		if(code instanceof Integer) {
-			if((Integer) code >= 200 && (Integer) code < 300) {
-				this.description = defaultSuccessfulOperationDescription;
-			}
+	public void setCode(Integer code, String defaultSuccessfulOperationDescription) {
+		if(code >= 200 && code < 300) {
+			this.description = defaultSuccessfulOperationDescription;
 		}
+		// OpenAPI 3.0 requires response codes to be strings.
+		this.code = String.valueOf(code);
 	}
 
 	public String getDescription() {

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/AllLibraryClassAnalyser.genericity_on_endpoint.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/AllLibraryClassAnalyser.genericity_on_endpoint.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -43,7 +43,7 @@ paths:
               items:
                 $ref: '#/components/schemas/ActionDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -60,7 +60,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ActionDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -72,7 +72,7 @@ paths:
         - ActionResource
       operationId: ActionResource.getStatus
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_description_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_description_extension.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_name_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.configure_enum_name_extension.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_description_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_description_extension.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_list_description.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_list_description.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_name_extension.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.disable_enum_name_extension.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_as_value_function_precedence.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_as_value_function_precedence.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumAsValueFunctionPrecedenceController
       operationId: EnumAsValueFunctionPrecedenceController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_field_as_value.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_field_as_value.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFieldAsValueController
       operationId: EnumFieldAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_function_as_value.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_function_as_value.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumFunctionAsValueController
       operationId: EnumFunctionAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_too_much_as_value.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.enum_too_much_as_value.approved.txt
@@ -14,7 +14,7 @@ paths:
         - EnumTooMuchAsValueController
       operationId: EnumTooMuchAsValueController.getEnums
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input.approved.txt
@@ -22,7 +22,7 @@ paths:
               $ref: '#/components/schemas/OrderJacksonDto'
         description: the order to create
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: create
 components:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_1.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_1.approved.txt
@@ -18,7 +18,7 @@ paths:
       operationId: JacksonController1.findAll
       description: Find all orders
       responses:
-        200:
+        "200":
           description: all the orders
           content:
             application/json:
@@ -40,7 +40,7 @@ paths:
               $ref: '#/components/schemas/AccountJacksonDto'
         description: the account to be created
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: create
 components:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_input_and_output_2.approved.txt
@@ -18,7 +18,7 @@ paths:
       operationId: JacksonController1.findAll
       description: Find all orders
       responses:
-        200:
+        "200":
           description: all the orders
           content:
             application/json:
@@ -46,7 +46,7 @@ paths:
                     $ref: '#/components/schemas/OrderJacksonDto'
         description: the input object
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: create
   /api/4/resume:
@@ -68,7 +68,7 @@ paths:
                     $ref: '#/components/schemas/ResumeJacksonDto'
         description: the input object to create a resume
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: createResume
 components:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_output.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JacksonAnalyserTest.schema_only_for_output.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: JacksonController1.findAll
       description: Find all orders
       responses:
-        200:
+        "200":
           description: all the orders
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.basic_parsing.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.basic_parsing.approved.txt
@@ -29,7 +29,7 @@ paths:
               $ref: '#/components/schemas/SimpleUserDto'
         description: a dto still representing a SimpleUserDto
       responses:
-        200:
+        "200":
           description: still true or false
           content:
             '*/*':
@@ -55,7 +55,7 @@ paths:
               $ref: '#/components/schemas/Authority'
         description: a dto representing an Authority
       responses:
-        200:
+        "200":
           description: "0 if false, 1 if true"
           content:
             '*/*':
@@ -83,7 +83,7 @@ paths:
               $ref: '#/components/schemas/SimpleUserDto'
         description: a dto representing a SimpleUserDto
       responses:
-        200:
+        "200":
           description: true or false
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.default_error_responses.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.default_error_responses.approved.txt
@@ -25,7 +25,7 @@ paths:
       operationId: getAuthorities
       deprecated: true
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_one.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_one.approved.txt
@@ -19,7 +19,7 @@ paths:
       operationId: canEncapsulate
       description: Indicate if this class has the ability to encapsulate
       responses:
-        200:
+        "200":
           description: true if it can encapsulate
           content:
             '*/*':
@@ -32,7 +32,7 @@ paths:
       operationId: canPrettyPrint
       description: Indicate if this class has the ability to pretty print
       responses:
-        200:
+        "200":
           description: true if it can pretty print
           content:
             '*/*':
@@ -45,7 +45,7 @@ paths:
       operationId: getPageFunctionalities
       description: "Supported functionalities, as a page"
       responses:
-        200:
+        "200":
           description: the supported functionalities
           content:
             '*/*':
@@ -76,7 +76,7 @@ paths:
       description: Return the name of this controller
       summary: name getter
       responses:
-        200:
+        "200":
           description: the name
           content:
             '*/*':
@@ -96,7 +96,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: a pretty printed string
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_three.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_three.approved.txt
@@ -22,7 +22,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -35,7 +35,7 @@ paths:
       operationId: getPageFunctionalities
       description: "Supported functionalities, as a page"
       responses:
-        200:
+        "200":
           description: the supported functionalities
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two.approved.txt
@@ -22,7 +22,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -35,7 +35,7 @@ paths:
       operationId: getPageFunctionalities
       description: "Supported functionalities, as a page"
       responses:
-        200:
+        "200":
           description: the supported functionalities
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two_package_success.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two_package_success.approved.txt
@@ -22,7 +22,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -35,7 +35,7 @@ paths:
       operationId: getPageFunctionalities
       description: "Supported functionalities, as a page"
       responses:
-        200:
+        "200":
           description: the supported functionalities
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two_package_warning.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inheritance_test_two_package_warning.approved.txt
@@ -22,7 +22,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -35,7 +35,7 @@ paths:
       operationId: getPageFunctionalities
       description: "Supported functionalities, as a page"
       responses:
-        200:
+        "200":
           description: the supported functionalities
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inner_class_object.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inner_class_object.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inner_local_class_object.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.inner_local_class_object.approved.txt
@@ -24,7 +24,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: a user inner class object
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.markdown_comments.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JavadocParserTest.markdown_comments.approved.txt
@@ -38,7 +38,7 @@ paths:
               $ref: '#/components/schemas/SimpleUserDto'
         description: a dto representing a SimpleUserDto
       responses:
-        200:
+        "200":
           description: true or false
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jakarta_basic.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jakarta_basic.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: deleteAccount
   /api/account/update:
@@ -35,7 +35,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -54,7 +54,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -76,7 +76,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jakarta_jsonb_transient.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jakarta_jsonb_transient.approved.txt
@@ -14,7 +14,7 @@ paths:
         - JakartaIgnoreController
       operationId: JakartaIgnoreController.get
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jaxrs_basic.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jaxrs_basic.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
       x-operation-name: deleteAccount
   /api/account/update:
@@ -35,7 +35,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -54,7 +54,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -76,7 +76,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jaxrs_jsonb_transient.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.jaxrs_jsonb_transient.approved.txt
@@ -14,7 +14,7 @@ paths:
         - JavaxIgnoreController
       operationId: JavaxIgnoreController.get
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.optional_unmapping_jakarta.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.optional_unmapping_jakarta.approved.txt
@@ -14,7 +14,7 @@ paths:
         - OptionalController
       operationId: getClassValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -32,7 +32,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -44,7 +44,7 @@ paths:
         - OptionalController
       operationId: getInterfaceValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -62,7 +62,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.optional_unmapping_jaxrs.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.optional_unmapping_jaxrs.approved.txt
@@ -14,7 +14,7 @@ paths:
         - OptionalController
       operationId: getClassValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -32,7 +32,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -44,7 +44,7 @@ paths:
         - OptionalController
       operationId: getInterfaceValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -62,7 +62,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.response_jaxrs_jakarta.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.response_jaxrs_jakarta.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ResponseJaxrsController
       operationId: ResponseJaxrsController.directlyPresent
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -27,7 +27,7 @@ paths:
         - ResponseJaxrsController
       operationId: ResponseJaxrsController.indirectlyPresent
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.response_jaxrs_javax.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/JaxrsClassAnalyserTest.response_jaxrs_javax.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ResponseJaxrsController
       operationId: ResponseJaxrsController.directlyPresent
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -27,7 +27,7 @@ paths:
         - ResponseJaxrsController
       operationId: ResponseJaxrsController.indirectlyPresent
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.enum_substitution.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.enum_substitution.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ResponseEntityController
       operationId: ResponseEntityController.getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.object_substitution.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.object_substitution.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ResponseEntityController
       operationId: ResponseEntityController.getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.object_substitution_json_content.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/ModelSubstitutionTest.object_substitution_json_content.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ResponseEntityController
       operationId: ResponseEntityController.getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.annotated_controller.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.annotated_controller.approved.txt
@@ -14,7 +14,7 @@ paths:
         - AnnotatedController
       operationId: getCounter
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_class.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_class.approved.txt
@@ -14,7 +14,7 @@ paths:
         - GenericityTestOne
       operationId: getFirstObject
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -98,7 +98,7 @@ paths:
                     hasNext:
                       type: boolean
       responses:
-        200:
+        "200":
           description: successful operation
   /api/genericity-test-one/second-object:
     get:
@@ -106,7 +106,7 @@ paths:
         - GenericityTestOne
       operationId: getSecondObject
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -192,7 +192,7 @@ paths:
                     hasNext:
                       type: boolean
       responses:
-        200:
+        "200":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_class_method.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_class_method.approved.txt
@@ -14,7 +14,7 @@ paths:
         - AccountController
       operationId: getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -30,7 +30,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/activate:
     get:
@@ -44,7 +44,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/register:
     post:
@@ -57,7 +57,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ManagedUserDto'
       responses:
-        201:
+        "201":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_method.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.black_list_method.approved.txt
@@ -14,7 +14,7 @@ paths:
         - AccountController
       operationId: getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -30,7 +30,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/activate:
     get:
@@ -44,7 +44,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/register:
     post:
@@ -57,7 +57,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ManagedUserDto'
       responses:
-        201:
+        "201":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.collection.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.collection.approved.txt
@@ -22,7 +22,7 @@ paths:
                 type: integer
                 format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.empty_value_query_parameter.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.empty_value_query_parameter.approved.txt
@@ -31,7 +31,7 @@ paths:
           required: false
           allowEmptyValue: true
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enpoint_path_collision.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enpoint_path_collision.approved.txt
@@ -20,7 +20,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_1.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_1.approved.txt
@@ -15,7 +15,7 @@ paths:
       operationId: getAuthorities
       deprecated: true
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_2.approved.txt
@@ -14,7 +14,7 @@ paths:
         - TestEnumeration2Controller
       operationId: getAuthorities
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_3.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_3.approved.txt
@@ -14,7 +14,7 @@ paths:
         - TestEnumeration3Controller
       operationId: getAuthority
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_4.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_4.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/EnumTest1Dto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_5.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_5.approved.txt
@@ -21,7 +21,7 @@ paths:
               items:
                 $ref: '#/components/schemas/Authority'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_6.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_6.approved.txt
@@ -20,7 +20,7 @@ paths:
           schema:
             $ref: '#/components/schemas/Authority'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_7.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.enumeration_test_7.approved.txt
@@ -14,7 +14,7 @@ paths:
         - TestEnumeration7Controller
       operationId: getTerritories
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.error_same_operation.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.error_same_operation.approved.txt
@@ -14,7 +14,7 @@ paths:
         - SameOperationController
       operationId: getAuthorities
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -30,7 +30,7 @@ paths:
         - SameOperationController
       operationId: getAuthorityList
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_list.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_list.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: getListUUID
       description: Get a list of uuids
       responses:
-        200:
+        "200":
           description: uuid list
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_list2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_list2.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ExtendsListV2
       operationId: getList
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_map.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extends_map.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: getChildMap
       description: Get a child map
       responses:
-        200:
+        "200":
           description: a child map
           content:
             '*/*':
@@ -41,5 +41,5 @@ paths:
                 format: int64
         description: some map
       responses:
-        200:
+        "200":
           description: successful operation

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extra_classes.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.extra_classes.approved.txt
@@ -22,7 +22,7 @@ paths:
                 type: integer
                 format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.file_upload.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.file_upload.approved.txt
@@ -34,7 +34,7 @@ paths:
                     type: string
                     format: binary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -70,7 +70,7 @@ paths:
                   type: string
                   format: binary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -100,7 +100,7 @@ paths:
                     type: string
                     format: binary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -132,7 +132,7 @@ paths:
                   type: string
                   format: binary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_object_mapping.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_object_mapping.approved.txt
@@ -23,5 +23,5 @@ paths:
               additionalProperties: {}
         description: my map
       responses:
-        200:
+        "200":
           description: successful operation

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_object_mapping2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_object_mapping2.approved.txt
@@ -14,7 +14,7 @@ paths:
         - ExtendsGenericObjectMap
       operationId: getMap
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_parent_bound_by_child.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_parent_bound_by_child.approved.txt
@@ -22,7 +22,7 @@ paths:
               $ref: '#/components/schemas/ChildRequestDto'
         description: some price request
       responses:
-        200:
+        "200":
           description: the requested item
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_parent_bound_by_child_extrends_interface.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_parent_bound_by_child_extrends_interface.approved.txt
@@ -22,7 +22,7 @@ paths:
               $ref: '#/components/schemas/ChildRequestDtoInterface'
         description: some price request
       responses:
-        200:
+        "200":
           description: the requested item
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_dto.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: getRecursive
       description: Return the recursive generic object
       responses:
-        200:
+        "200":
           description: something
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_interface_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_interface_dto.approved.txt
@@ -14,7 +14,7 @@ paths:
         - GenericRecursiveInterfaceDtoController
       operationId: getRecursive
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_interface_list_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_interface_list_dto.approved.txt
@@ -37,7 +37,7 @@ paths:
                 wrapped:
                   $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_list_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generic_recursive_list_dto.approved.txt
@@ -14,7 +14,7 @@ paths:
         - GenericRecursiveListDtoController
       operationId: getRecursive
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generically_typed_controller.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.generically_typed_controller.approved.txt
@@ -14,7 +14,7 @@ paths:
         - GenericDataController
       operationId: getDataList
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_cross_reference.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_cross_reference.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteriaV4'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_cross_reference_in_super_constructor.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_cross_reference_in_super_constructor.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteriaV42'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends_class_in_parameter.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends_class_in_parameter.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteria'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends_class_in_parameter_v2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_extends_class_in_parameter_v2.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteriaV2'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_in_super_constructor.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_in_super_constructor.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteriaChildV6'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_list_long.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_list_long.approved.txt
@@ -29,5 +29,5 @@ paths:
               type: integer
               format: int64
       responses:
-        200:
+        "200":
           description: successful operation

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_reference_self_class.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_reference_self_class.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/SearchCriteriaV3'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_typed_wrapped_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_typed_wrapped_dto.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_wrapped_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.genericity_wrapped_dto.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.interface_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.interface_dto.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: getInterfaceDto
       description: This endpoint returns an interface
       responses:
-        200:
+        "200":
           description: the returned interface
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_138.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_138.approved.txt
@@ -14,7 +14,7 @@ paths:
         - Issue138
       operationId: issue138
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_246.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_246.approved.txt
@@ -14,7 +14,7 @@ paths:
         - Issue246
       operationId: getLogs
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -28,7 +28,7 @@ paths:
         - Issue246
       operationId: getLogs2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -42,7 +42,7 @@ paths:
         - Issue246
       operationId: getLogs3
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_247.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_247.approved.txt
@@ -14,7 +14,7 @@ paths:
         - Issue247
       operationId: getEmployees
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -26,7 +26,7 @@ paths:
         - Issue247
       operationId: getEmployeesArrayOfList
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_262.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_262.approved.txt
@@ -21,5 +21,5 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_263.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_263.approved.txt
@@ -42,9 +42,9 @@ paths:
                 contentType: application/octet-stream
         description: a time in the "execute" case
       responses:
-        204:
+        "204":
           description: successful operation
-        200:
+        "200":
           description: a PageDto of string in the "checkFile" case
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_89.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_89.approved.txt
@@ -22,7 +22,7 @@ paths:
               $ref: '#/components/schemas/Bar'
         description: my awesome parameter
       responses:
-        200:
+        "200":
           description: my also awesome response
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_95.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.issue_95.approved.txt
@@ -14,7 +14,7 @@ paths:
         - Issue95
       operationId: error
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.jacksonJsonProperty.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.jacksonJsonProperty.approved.txt
@@ -19,7 +19,7 @@ paths:
         *SimpleUserDto*
         [https://kbuntrock.github.io/openapi-maven-plugin](https://kbuntrock.github.io/openapi-maven-plugin)
       responses:
-        200:
+        "200":
           description: the list of users.
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.json_ignore.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.json_ignore.approved.txt
@@ -14,7 +14,7 @@ paths:
         - JsonIgnoreController
       operationId: get
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.map_objects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.map_objects.approved.txt
@@ -14,7 +14,7 @@ paths:
         - MapController
       operationId: getMapString
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -28,7 +28,7 @@ paths:
         - MapController
       operationId: getMapUsers
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -49,7 +49,7 @@ paths:
               additionalProperties:
                 $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -68,7 +68,7 @@ paths:
               additionalProperties:
                 type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.model_attribute.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.model_attribute.approved.txt
@@ -36,7 +36,7 @@ paths:
             type: string
             format: date-time
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multipart_formdata.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multipart_formdata.approved.txt
@@ -43,7 +43,7 @@ paths:
               file:
                 contentType: application/octet-stream
       responses:
-        200:
+        "200":
           description: successful operation
   /api/file-controller/multiple:
     post:
@@ -80,7 +80,7 @@ paths:
               files:
                 contentType: application/json
       responses:
-        200:
+        "200":
           description: successful operation
   /api/file-controller/two:
     post:
@@ -123,7 +123,7 @@ paths:
               file2:
                 contentType: application/octet-stream
       responses:
-        200:
+        "200":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_content_type.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_content_type.approved.txt
@@ -29,7 +29,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_content_type_parameter_incoherence.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_content_type_parameter_incoherence.approved.txt
@@ -44,7 +44,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_genericity.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_genericity.approved.txt
@@ -14,7 +14,7 @@ paths:
         - GenericityTestOne
       operationId: getFirstObject
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -98,7 +98,7 @@ paths:
                     hasNext:
                       type: boolean
       responses:
-        200:
+        "200":
           description: successful operation
   /api/genericity-test-one/second-object:
     get:
@@ -106,7 +106,7 @@ paths:
         - GenericityTestOne
       operationId: getSecondObject
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -192,7 +192,7 @@ paths:
                     hasNext:
                       type: boolean
       responses:
-        200:
+        "200":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_headers_on_same_operation.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.multiple_headers_on_same_operation.approved.txt
@@ -26,7 +26,7 @@ paths:
           required: false
           schema: {}
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.name_collision.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.name_collision.approved.txt
@@ -15,7 +15,7 @@ paths:
         - FirstEndpoint
       operationId: getCompleteAccounts
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -34,7 +34,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Authority_2'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -48,7 +48,7 @@ paths:
         - SecondEndpoint
       operationId: getPartialAccounts
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nested_dtos.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nested_dtos.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserGroupDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -38,7 +38,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -57,7 +57,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nested_genericity.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nested_genericity.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -44,7 +44,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -82,7 +82,7 @@ paths:
                   type: integer
                   format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -94,7 +94,7 @@ paths:
         - GenericityTestTwo
       operationId: getAuthorityPage
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -126,7 +126,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -150,7 +150,7 @@ paths:
         - GenericityTestTwo
       operationId: getTimePage
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_custom_annotation.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_custom_annotation.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_non_nullable.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_non_nullable.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_non_nullable_custom_annotation.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_default_non_nullable_custom_annotation.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_getters_setters.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_getters_setters.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_getters_setters_default_non_nullable.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.nullable_getters_setters_default_non_nullable.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.numbers.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.numbers.approved.txt
@@ -21,7 +21,7 @@ paths:
             type: number
             format: double
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.object_mapping.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.object_mapping.approved.txt
@@ -14,7 +14,7 @@ paths:
         - MappingObject
       operationId: getNonWrappedObjectMap
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -27,7 +27,7 @@ paths:
         - MappingObject
       operationId: getObject
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -41,7 +41,7 @@ paths:
           '*/*':
             schema: {}
       responses:
-        200:
+        "200":
           description: successful operation
   /mapping-object/object-map:
     get:
@@ -49,7 +49,7 @@ paths:
         - MappingObject
       operationId: getObjectMap
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.optional.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.optional.approved.txt
@@ -14,7 +14,7 @@ paths:
         - OptionalController
       operationId: getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -26,7 +26,7 @@ paths:
         - OptionalController
       operationId: getWrappedAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.optional_unmapping.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.optional_unmapping.approved.txt
@@ -14,7 +14,7 @@ paths:
         - OptionalController
       operationId: getClassValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -32,7 +32,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -44,7 +44,7 @@ paths:
         - OptionalController
       operationId: getInterfaceValue
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -62,7 +62,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.package_private.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.package_private.approved.txt
@@ -14,7 +14,7 @@ paths:
         - PackagePrivateResource
       operationId: getAllPackagePrivate
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -28,7 +28,7 @@ paths:
         - PackagePrivateResource
       operationId: getAllProtected
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.pathEnhancement.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.pathEnhancement.approved.txt
@@ -14,7 +14,7 @@ paths:
         - SpringPathEnhancementOneController
       operationId: getTwo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -26,7 +26,7 @@ paths:
         - SpringPathEnhancementOneController
       operationId: getOne
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_dto_binding.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_dto_binding.approved.txt
@@ -36,7 +36,7 @@ paths:
             type: string
             format: date-time
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_flat_mix_nested_dto_binding.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_flat_mix_nested_dto_binding.approved.txt
@@ -47,7 +47,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_in_mapping.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.query_param_in_mapping.approved.txt
@@ -23,7 +23,7 @@ paths:
           required: false
           schema: {}
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -40,7 +40,7 @@ paths:
           required: false
           allowEmptyValue: true
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.recursive_dto.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.recursive_dto.approved.txt
@@ -14,7 +14,7 @@ paths:
         - RecursiveDtoController
       operationId: getRecursive
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.recursive_dto_in_parameter.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.recursive_dto_in_parameter.approved.txt
@@ -19,7 +19,7 @@ paths:
             schema:
               $ref: '#/components/schemas/RecursiveDto'
       responses:
-        200:
+        "200":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.request_headers.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.request_headers.approved.txt
@@ -41,7 +41,7 @@ paths:
                   format: binary
         description: the provided file
       responses:
-        200:
+        "200":
           description: "OK if upload in success, KO otherwise"
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.response_entity.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.response_entity.approved.txt
@@ -16,7 +16,7 @@ paths:
       operationId: getAccount
       description: Get an account object
       responses:
-        200:
+        "200":
           description: the return account
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.response_entity_unparametrized.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.response_entity_unparametrized.approved.txt
@@ -15,7 +15,7 @@ paths:
         - ResponseEntityUnparametrizedController
       operationId: getInformation
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.stream_download.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.stream_download.approved.txt
@@ -14,7 +14,7 @@ paths:
         - StreamResponseController
       operationId: getByteArray
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/octet-stream:
@@ -27,7 +27,7 @@ paths:
         - StreamResponseController
       operationId: getStream
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/octet-stream:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.tag_name_collision.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.tag_name_collision.approved.txt
@@ -14,7 +14,7 @@ paths:
         - MyController
       operationId: getInfo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -25,7 +25,7 @@ paths:
         - MyController
       operationId: setInfo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -36,7 +36,7 @@ paths:
         - MyController
       operationId: putInfo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -47,7 +47,7 @@ paths:
         - MyController
       operationId: patchInfo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -58,7 +58,7 @@ paths:
         - MyController
       operationId: deleteInfo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -70,7 +70,7 @@ paths:
         - MyController
       operationId: getInfo2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -81,7 +81,7 @@ paths:
         - MyController
       operationId: setInfo2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -92,7 +92,7 @@ paths:
         - MyController
       operationId: putInfo2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -103,7 +103,7 @@ paths:
         - MyController
       operationId: patchInfo2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -114,7 +114,7 @@ paths:
         - MyController
       operationId: deleteInfo2
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.time_objects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.time_objects.approved.txt
@@ -14,7 +14,7 @@ paths:
         - TimeController
       operationId: getTimeDto
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.uuid.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.uuid.approved.txt
@@ -24,7 +24,7 @@ paths:
             type: string
             format: uuid
       responses:
-        200:
+        "200":
           description: a list of ids
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_class.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_class.approved.txt
@@ -22,7 +22,7 @@ paths:
             type: number
             format: double
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -34,7 +34,7 @@ paths:
         - TimeController
       operationId: getTimeDto
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_class_method.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_class_method.approved.txt
@@ -20,5 +20,5 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_method.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_method.approved.txt
@@ -14,7 +14,7 @@ paths:
         - AccountController
       operationId: getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -30,7 +30,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/activate:
     get:
@@ -44,7 +44,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/register:
     post:
@@ -57,7 +57,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ManagedUserDto'
       responses:
-        201:
+        "201":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_method2.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.white_list_method2.approved.txt
@@ -14,7 +14,7 @@ paths:
         - AccountController
       operationId: getAccount
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -30,7 +30,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AccountDto'
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/activate:
     get:
@@ -44,7 +44,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
   /api/account/register:
     post:
@@ -57,7 +57,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ManagedUserDto'
       responses:
-        201:
+        "201":
           description: successful operation
 components:
   schemas:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.OneParametersOutTwoParametersInNoMerge.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.OneParametersOutTwoParametersInNoMerge.approved.txt
@@ -35,7 +35,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithAllMerged.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithAllMerged.approved.txt
@@ -32,7 +32,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithPriority.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersEmptyInWithPriority.approved.txt
@@ -32,7 +32,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInNoMerge.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInNoMerge.approved.txt
@@ -42,7 +42,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithAllMerged.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithAllMerged.approved.txt
@@ -32,7 +32,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithMerge.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.TwoParametersOutTwoParametersInWithMerge.approved.txt
@@ -37,7 +37,7 @@ paths:
             type: integer
             format: int32
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedAndJavadocResponseWithReturnObjects.approved.txt
@@ -15,19 +15,19 @@ paths:
       operationId: different_errors
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ResponseEntityWithAnnotations'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -40,7 +40,7 @@ paths:
       operationId: swaggerSummary
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -53,20 +53,20 @@ paths:
       operationId: unparametrized
       summary: Swagger summary of unparametrized operation
       responses:
-        200:
+        "200":
           description: The success response
           content:
             '*/*':
               schema:
                 description: The success entity
                 $ref: '#/components/schemas/SuccessEntity'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjects.approved.txt
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -57,7 +57,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -78,7 +78,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -57,7 +57,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -78,7 +78,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicAnnotatedResponseWithReturnObjects.approved.txt
@@ -15,19 +15,19 @@ paths:
       operationId: different_errors
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ResponseEntityWithAnnotations'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -40,7 +40,7 @@ paths:
       operationId: swaggerSummary
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -53,20 +53,20 @@ paths:
       operationId: unparametrized
       summary: Swagger summary of unparametrized operation
       responses:
-        200:
+        "200":
           description: The success response
           content:
             '*/*':
               schema:
                 description: The success entity
                 $ref: '#/components/schemas/SuccessEntity'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicApiResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.basicApiResponseWithReturnObjects.approved.txt
@@ -16,19 +16,19 @@ paths:
       operationId: errorResponses
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 type: string
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntity'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -41,13 +41,13 @@ paths:
       operationId: errorResponsesWithNoAndErrorInResponseCode
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 type: string
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -60,7 +60,7 @@ paths:
       operationId: swaggerSummary
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjects.approved.txt
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -57,7 +57,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -78,7 +78,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedParametersWithReturnObjectsWithJavadoc.approved.txt
@@ -37,7 +37,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -57,7 +57,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -78,7 +78,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicAnnotatedResponseWithReturnObjects.approved.txt
@@ -15,19 +15,19 @@ paths:
       operationId: different_errors
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ResponseEntityWithAnnotations'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -40,7 +40,7 @@ paths:
       operationId: swaggerSummary
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -53,20 +53,20 @@ paths:
       operationId: unparametrized
       summary: Swagger summary of unparametrized operation
       responses:
-        200:
+        "200":
           description: The success response
           content:
             '*/*':
               schema:
                 description: The success entity
                 $ref: '#/components/schemas/SuccessEntity'
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntityWithAnnotations'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicApiResponseWithReturnObjects.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SwaggerAnalyzerTest.jakartaBasicApiResponseWithReturnObjects.approved.txt
@@ -16,19 +16,19 @@ paths:
       operationId: errorResponses
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 type: string
-        404:
+        "404":
           description: Not Found
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorEntity'
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -41,13 +41,13 @@ paths:
       operationId: errorResponsesWithNoAndErrorInResponseCode
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: Swagger Successful operation
           content:
             '*/*':
               schema:
                 type: string
-        500:
+        "500":
           description: Internal server error
           content:
             '*/*':
@@ -60,7 +60,7 @@ paths:
       operationId: swaggerSummary
       summary: Swagger summary
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':

--- a/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case.yml
+++ b/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case.yml
@@ -34,7 +34,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: the user and his updated data
       responses:
-        200:
+        "200":
           description: the updated user
           content:
             application/json:
@@ -51,7 +51,7 @@ paths:
       operationId: getUserDtos
       description: Get a list of all the users of the application
       responses:
-        200:
+        "200":
           description: a list of all the users of the application
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case_impl.yml
+++ b/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case_impl.yml
@@ -31,7 +31,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: the user and his updated data
       responses:
-        200:
+        "200":
           description: the updated user
           content:
             application/json:
@@ -48,7 +48,7 @@ paths:
       operationId: getUserDtos
       description: Get a list of all the users of the application
       responses:
-        200:
+        "200":
           description: a list of all the users of the application
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case_jaxrs.yml
+++ b/openapi-maven-plugin/src/test/resources/it/BasicIT/nominal_test_case_jaxrs.yml
@@ -22,7 +22,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: the user and his updated data
       responses:
-        200:
+        "200":
           description: the updated user
           content:
             application/json:
@@ -36,7 +36,7 @@ paths:
       operationId: UserController.getUserDtos
       description: Get a list of all the users of the application
       responses:
-        200:
+        "200":
           description: a list of all the users of the application
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/BasicIT/sealed_class.yml
+++ b/openapi-maven-plugin/src/test/resources/it/BasicIT/sealed_class.yml
@@ -17,7 +17,7 @@ paths:
       operationId: ShapeController.getCircle
       description: Get a circle
       responses:
-        200:
+        "200":
           description: the circle object
           content:
             application/json:
@@ -31,7 +31,7 @@ paths:
       operationId: ShapeController.getStatus
       description: Get the api status
       responses:
-        200:
+        "200":
           description: the status of the shape api
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateNoJavadoc.yml
+++ b/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateNoJavadoc.yml
@@ -26,7 +26,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -39,7 +39,7 @@ paths:
         - UserController
       operationId: UserController.getUserDtos
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateWithCompileOption.yml
+++ b/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateWithCompileOption.yml
@@ -29,7 +29,7 @@ paths:
               $ref: '#/components/schemas/UserDto'
         description: the user and his updated data
       responses:
-        200:
+        "200":
           description: the updated user
           content:
             application/json:
@@ -43,7 +43,7 @@ paths:
       operationId: UserController.getUserDtos
       description: Get a list of all the users of the application
       responses:
-        200:
+        "200":
           description: a list of all the users of the application
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateWithoutCompileOption.yml
+++ b/openapi-maven-plugin/src/test/resources/it/CmdLineIT/generateWithoutCompileOption.yml
@@ -28,7 +28,7 @@ paths:
             schema:
               $ref: '#/components/schemas/UserDto'
       responses:
-        200:
+        "200":
           description: the updated user
           content:
             application/json:
@@ -42,7 +42,7 @@ paths:
       operationId: UserController.getUserDtos
       description: Get a list of all the users of the application
       responses:
-        200:
+        "200":
           description: a list of all the users of the application
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/ut/AllLibraryClassAnalyser/genericity_on_endpoint.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/AllLibraryClassAnalyser/genericity_on_endpoint.yml
@@ -21,7 +21,7 @@ paths:
             type: integer
             format: int64
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -43,7 +43,7 @@ paths:
               items:
                 $ref: '#/components/schemas/ActionDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -61,7 +61,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ActionDto'
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:
@@ -74,7 +74,7 @@ paths:
         - ActionResource
       operationId: ActionResource.getStatus
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             application/json:

--- a/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/springPathEnhancementTwo.yml
+++ b/openapi-maven-plugin/src/test/resources/ut/SpringClassAnalyserTest/springPathEnhancementTwo.yml
@@ -14,7 +14,7 @@ paths:
         - SpringPathEnhancementTwoController
       operationId: getTwo
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':
@@ -26,7 +26,7 @@ paths:
         - SpringPathEnhancementTwoController
       operationId: getOne
       responses:
-        200:
+        "200":
           description: successful operation
           content:
             '*/*':


### PR DESCRIPTION
## Problem

The plugin generates HTTP response codes as unquoted YAML numeric keys:

```yaml
responses:
  200:
    description: successful operation
```

This violates the [OpenAPI 3.0.3 specification (section 4.8.16.1 — Responses Object)](https://spec.openapis.org/oas/v3.0.3#responses-object), which states:

> *"Any HTTP status code can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. This field MUST be enclosed in quotation marks (e.g. "200") for compatibility between JSON and YAML."*

As a consequence, [Spectral](https://github.com/stoplightio/spectral) (the standard OpenAPI linter) raises a parser error on the generated specs:

```
error  parser  Mapping key must be a string scalar rather than number
```

## Fix

**`Response.java`** — Convert the response code from `Integer` to `String` in `setCode()` via `String.valueOf()`. The parameter remains `Integer` to preserve compile-time type safety (guarantees only numeric codes). The stored value becomes a `String`, so Jackson/YAML serialization produces `"200":` instead of `200:`.

**`YamlWriter.java`** — Align the Swagger annotation merge lookup (line 457) to use `String.valueOf(operationResponse.getCode())`. Without this, the lookup key (`Integer`) would not match the map key (`String`), causing the merge to silently create a new empty response instead of enriching the existing one.

## Test plan

- All 145 unit tests updated and passing
- Test reference files updated via `sed` (only numeric key quoting, no other changes)
- Integration tests validated by CI