### PR TITLE
[Doc] Add java annotation custom style

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,8 +1,8 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
-import type {PluginsParams} from 'svgo/plugins/plugins-types';
-import * as path from "node:path";
+import type { Config } from '@docusaurus/types';
+import type { PluginsParams } from 'svgo/plugins/plugins-types';
+import { darkTheme, lightTheme } from './src/css/theme';
+
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -190,8 +190,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Openapi Maven Plugin`,
     },
     prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      theme: lightTheme,
+      darkTheme: darkTheme,
       additionalLanguages: ['java'],
     },
     announcementBar: {

--- a/docs/src/css/theme.ts
+++ b/docs/src/css/theme.ts
@@ -1,0 +1,27 @@
+import { PrismTheme, themes as prismThemes } from "prism-react-renderer";
+
+const _darkTheme: PrismTheme = {
+  ...prismThemes.oneDark,
+};
+
+_darkTheme.styles.push({
+  types: ["token", "annotation", "punctuation"],
+  style: {
+    color: "hsl(41, 63%, 40%)",
+  },
+});
+
+const _lightTheme: PrismTheme = {
+  ...prismThemes.oneLight,
+};
+
+_lightTheme.styles.push({
+  types: ["token", "annotation", "punctuation"],
+  style: {
+    color: "hsl(41, 63%, 40%)",
+  },
+});
+
+export const lightTheme = _lightTheme;
+
+export const darkTheme = _darkTheme;


### PR DESCRIPTION
Override oneDark and oneLight themes in order to highligth java annotation.

Theme have been changed to get yaml colors (dracula and github hasn't)

Fix #374 