### PR TITLE
fix: propagate @Schema(description, example) on DTO fields to query parameter descriptions

### DIFF
--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/configuration/library/reader/SpringMvcReader.java
@@ -5,6 +5,7 @@ import io.github.kbuntrock.MojoRuntimeException;
 import io.github.kbuntrock.configuration.ApiConfiguration;
 import io.github.kbuntrock.context.ApiContext;
 import io.github.kbuntrock.model.*;
+import io.github.kbuntrock.reflection.BeanDefinition;
 import io.github.kbuntrock.reflection.annotation.MergedAnnotation;
 import io.github.kbuntrock.reflection.annotation.MergedAnnotations;
 import io.github.kbuntrock.utils.OpenApiTypeResolver;
@@ -16,6 +17,7 @@ import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.maven.plugin.MojoFailureException;
 
 import java.io.File;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -416,7 +418,38 @@ public class SpringMvcReader extends AbstractLibraryReader {
 		if(childObject.getDataObject().getClassRequired() != null) {
 			fieldObj.setRequired(childObject.getDataObject().getClassRequired());
 		}
+
+		// Inherit description and example from @Schema annotation on the field.
+		// Mirrors yaml.model.Schema#setPropertyDescriptionFromSwaggerAnnotation to give DTO-bound
+		// query parameters the same documentation power as schema properties.
+		setParameterDescriptionFromSwaggerAnnotation(childObject.getBeanDefinition(), fieldObj);
+
 		return fieldObj;
+	}
+
+	private void setParameterDescriptionFromSwaggerAnnotation(final BeanDefinition beanDefinition,
+		final ParameterObject fieldObj) {
+		if(beanDefinition.hasField()) {
+			readSchemaAnnotationOnto(beanDefinition.getField().getAnnotated(), fieldObj);
+		}
+		if(beanDefinition.hasGetter()) {
+			readSchemaAnnotationOnto(beanDefinition.getGetter().getAnnotated(), fieldObj);
+		}
+	}
+
+	private void readSchemaAnnotationOnto(final AnnotatedElement element, final ParameterObject fieldObj) {
+		final MergedAnnotation schemaAnnotation = context.getMergeAnnotationsHelper().from(element)
+			.get("io.swagger.v3.oas.annotations.media.Schema");
+		if(schemaAnnotation.isPresent()) {
+			final String swaggerDescription = schemaAnnotation.getString("description");
+			if(!StringUtils.isEmpty(swaggerDescription)) {
+				fieldObj.setDescription(swaggerDescription);
+			}
+			final String swaggerExample = schemaAnnotation.getString("example");
+			if(!StringUtils.isEmpty(swaggerExample)) {
+				fieldObj.setExample(swaggerExample);
+			}
+		}
 	}
 
 	@Override

--- a/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
+++ b/openapi-maven-plugin/src/main/java/io/github/kbuntrock/yaml/YamlWriter.java
@@ -337,11 +337,18 @@ public class YamlWriter {
 							final JavadocWrapper javadocParamWrapper = queryParamBindingClassDoc.getFieldsJavadoc()
 								.get(parameterElement.getName());
 							if(javadocParamWrapper != null) {
+								// Only override the description/summary when the Javadoc actually provides a value.
+								// Otherwise a missing Javadoc would erase any description already set from
+								// the @Schema annotation on the DTO field.
 								final Optional<String> desc = javadocParamWrapper.getDescription();
-								parameterElement.setDescription(desc.orElse(null));
+								if(desc.isPresent() && !desc.get().isEmpty()) {
+									parameterElement.setDescription(desc.get());
+								}
 
 								final Optional<String> summary = javadocParamWrapper.getSummary();
-								parameterElement.setSummary(summary.orElse(null));
+								if(summary.isPresent() && !summary.get().isEmpty()) {
+									parameterElement.setSummary(summary.get());
+								}
 							}
 						}
 					}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/SpringClassAnalyserTest.java
@@ -803,6 +803,18 @@ public class SpringClassAnalyserTest extends AbstractTest {
 	}
 
 	@Test
+	public void schema_description_on_dto_query_param() throws MojoFailureException, IOException, MojoExecutionException {
+
+		final DocumentationMojo mojo = createBasicMojo(SchemaDescriptionDtoController.class.getCanonicalName());
+		final JavadocConfiguration javadocConfig = new JavadocConfiguration();
+		javadocConfig.setScanLocations(Arrays.asList("src/test/java/io/github/kbuntrock/resources/endpoint/queryparam",
+			"src/test/java/io/github/kbuntrock/resources/dto"));
+		mojo.setJavadocConfiguration(javadocConfig);
+
+		checkGenerationResult(mojo.documentProject());
+	}
+
+	@Test
 	public void query_param_flat_mix_nested_dto_binding() throws MojoFailureException, IOException, MojoExecutionException {
 
 		final DocumentationMojo mojo = createBasicMojo(QueryParamFlatMixNestedDtoBindingController.class.getCanonicalName());

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/SchemaDescriptionDto.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/dto/SchemaDescriptionDto.java
@@ -1,0 +1,60 @@
+package io.github.kbuntrock.resources.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO used by tests that verify {@code @Schema(description = ...)} on DTO fields
+ * is propagated to OpenAPI query parameter descriptions, when the field has no
+ * Javadoc to drive the description.
+ */
+public class SchemaDescriptionDto {
+
+	@Schema(description = "Description coming from Schema annotation", example = "schemaValue")
+	private String fieldFromSchemaOnly;
+
+	/**
+	 * Description coming from Javadoc
+	 */
+	private String fieldFromJavadocOnly;
+
+	/**
+	 * Description coming from Javadoc (wins)
+	 */
+	@Schema(description = "Description coming from Schema (loses)", example = "javadocFieldExample")
+	private String fieldFromBothJavadocWins;
+
+	@Schema(example = "exampleOnly")
+	private String fieldWithExampleFromSchemaOnly;
+
+	public String getFieldFromSchemaOnly() {
+		return fieldFromSchemaOnly;
+	}
+
+	public void setFieldFromSchemaOnly(final String fieldFromSchemaOnly) {
+		this.fieldFromSchemaOnly = fieldFromSchemaOnly;
+	}
+
+	public String getFieldFromJavadocOnly() {
+		return fieldFromJavadocOnly;
+	}
+
+	public void setFieldFromJavadocOnly(final String fieldFromJavadocOnly) {
+		this.fieldFromJavadocOnly = fieldFromJavadocOnly;
+	}
+
+	public String getFieldFromBothJavadocWins() {
+		return fieldFromBothJavadocWins;
+	}
+
+	public void setFieldFromBothJavadocWins(final String fieldFromBothJavadocWins) {
+		this.fieldFromBothJavadocWins = fieldFromBothJavadocWins;
+	}
+
+	public String getFieldWithExampleFromSchemaOnly() {
+		return fieldWithExampleFromSchemaOnly;
+	}
+
+	public void setFieldWithExampleFromSchemaOnly(final String fieldWithExampleFromSchemaOnly) {
+		this.fieldWithExampleFromSchemaOnly = fieldWithExampleFromSchemaOnly;
+	}
+}

--- a/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/SchemaDescriptionDtoController.java
+++ b/openapi-maven-plugin/src/test/java/io/github/kbuntrock/resources/endpoint/queryparam/SchemaDescriptionDtoController.java
@@ -1,0 +1,13 @@
+package io.github.kbuntrock.resources.endpoint.queryparam;
+
+import io.github.kbuntrock.resources.dto.SchemaDescriptionDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("api/schema-description")
+public interface SchemaDescriptionDtoController {
+
+	@GetMapping("query")
+	boolean query(SchemaDescriptionDto filter);
+
+}

--- a/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.schema_description_on_dto_query_param.approved.txt
+++ b/openapi-maven-plugin/src/test/resources/io/github/kbuntrock/SpringClassAnalyserTest.schema_description_on_dto_query_param.approved.txt
@@ -1,0 +1,49 @@
+---
+openapi: 3.0.3
+info:
+  title: My Project
+  version: 10.5.36
+servers:
+  - url: ""
+tags:
+  - name: SchemaDescriptionDtoController
+paths:
+  /api/schema-description/query:
+    get:
+      tags:
+        - SchemaDescriptionDtoController
+      operationId: query
+      parameters:
+        - name: fieldFromSchemaOnly
+          description: Description coming from Schema annotation
+          example: schemaValue
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: fieldFromJavadocOnly
+          description: Description coming from Javadoc
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: fieldFromBothJavadocWins
+          description: Description coming from Javadoc (wins)
+          example: javadocFieldExample
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: fieldWithExampleFromSchemaOnly
+          example: exampleOnly
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            '*/*':
+              schema:
+                type: boolean


### PR DESCRIPTION
### Summary

When a DTO is bound as query parameters of a `@GetMapping` endpoint (via Spring's
implicit `@ModelAttribute` binding), the plugin only honored the field's Javadoc
for the parameter `description`. Field-level `@Schema(description = "...")` /
`@Schema(example = "...")` annotations were ignored.

The same `@Schema(description = "...")` is correctly read on the
`components.schemas.X.properties.Y.description` path, so the behavior was
inconsistent across the two paths.

### Before

```java
public class WirelessBzTargetDetailFilterDTO {

    @Schema(description = "Typhoon level (1/2/3)", example = "1")
    private Integer typhoonLevel;

    @Schema(description = "Target day count (1/3/7)", example = "1")
    private Integer targetDayNum;
}
```

Generated OpenAPI:

```yaml
- name: typhoonLevel
  in: query
  required: false
  schema:
    type: integer            # <-- no description / example
- name: targetDayNum
  in: query
  required: false
  schema:
    type: integer            # <-- no description / example
```

### After

```yaml
- name: typhoonLevel
  description: Typhoon level (1/2/3)
  example: '1'
  in: query
  required: false
  schema:
    type: integer
- name: targetDayNum
  description: Target day count (1/3/7)
  example: '1'
  in: query
  required: false
  schema:
    type: integer
```

### Changes

1. `SpringMvcReader.bindDtoToQueryParams` — when binding a DTO field to a
   query parameter, now also reads `@Schema(description, example)` from the
   field and getter. The lookup logic mirrors what is already used in
   `components.schemas` so the two paths stay consistent.

2. `YamlWriter` (line 339-345) — when applying the Javadoc fallback for a
   parameter that came from a DTO field, only override
   `description`/`summary` if Javadoc provides a non-empty value. Previously
   an empty Javadoc would erase a description that was correctly set from
   `@Schema`.

### Precedence (unchanged)

When both Javadoc and `@Schema` exist on the same DTO field, Javadoc still
wins — this preserves the existing behavior for users who rely on Javadoc.

### Tests

Added `SpringClassAnalyserTest#schema_description_on_dto_query_param` and
`SchemaDescriptionDtoController` / `SchemaDescriptionDto`. The DTO covers
four scenarios:

| field | Schema desc | Javadoc | Schema example | expected |
|---|---|---|---|---|
| `fieldFromSchemaOnly` | yes | no | yes | desc + example from `@Schema` |
| `fieldFromJavadocOnly` | no | yes | no | desc from Javadoc, no example |
| `fieldFromBothJavadocWins` | yes | yes | yes | desc from Javadoc, example from `@Schema` |
| `fieldWithExampleFromSchemaOnly` | no | no | yes | no desc, example from `@Schema` |

The new approved YAML is committed alongside the test.
All 147 existing unit tests still pass:

```
[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Real-world driver

Many existing codebases (Spring + Swagger v3) only annotate DTOs with
`@Schema`, especially when using `@Data` from Lombok which discourages writing
Javadoc on the field. Today, every such DTO field shows up as an undocumented
query parameter in the generated OpenAPI / in any downstream tool (Apifox /
Swagger UI / Postman).

A quick scan on one of our internal services showed **540 out of 1556** query
parameters (~35%) missing descriptions purely because of this gap, even though
the source DTOs were fully annotated with `@Schema`.

### Notes

- Followed Coding Guidelines and `mvn formatter:format` reports no diff.
- Java 8 source compatibility preserved.
- No new dependency introduced (swagger-annotations is already a test-scope
  dependency that was used in this PR; main source uses Spring's
  `MergedAnnotation` mechanism that the plugin already relies on).
